### PR TITLE
Fix -d flag behaviour in backup and restore

### DIFF
--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -83,7 +83,7 @@ for SEQ_PREFIX in $(aws s3api list-objects-v2 --bucket ${BUCKET} --prefix ${PREF
         aws s3 cp s3://${BUCKET}/${key} - | age -d -i ${IDENTITY_FILE}
       fi
     done | mbuffer -m 1G -q | lz4 -d | btrfs receive ${DEST}
-    if [ "${PREV_SEQ}" != "" ]; then
+    if [ "${DELETE_PREVIOUS}" == true ] && [ ! -z "${PREV_SEQ}" ]; then
       echo "Deleting previous snapshot ${DEST}/${PREV_SEQ}"
       sudo btrfs subvolume delete ${DEST}/${PREV_SEQ}
     fi

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -127,7 +127,7 @@ btrfs subvolume show ${NEW_SNAPSHOT} \
   | age -R ${RECIPIENTS_FILE} \
   | aws s3 cp - s3://${BUCKET}/${PREFIX}/${EPOCH}/${SEQ_SALTED}/snapshot_info.dat
 
-if [ "${DELETE_PREVIOUS}" == true ]; then
+if [ "${DELETE_PREVIOUS}" == true ] && [ ! -z "${LAST_SNAPSHOT}" ]; then
   btrfs subvolume delete ${SUBV%%${SUBV_PREFIX}*}${LAST_SNAPSHOT}
 fi
 


### PR DESCRIPTION
In backup mode, the -d flag would attempt to delete a previous snapshot even if there wasn't any
In restore mode, the script would delete previous snapshots even if the -d flag wasn't supplied