### PR TITLE
Add a mock-based test harness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # The scripts refuse to run as anything but root.  Locally the suite puts
+      # itself in a user namespace; here it is simpler to just be root.
+      - name: Run the test suite
+        run: sudo ./tests/run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# The age recipients file the example crontab keeps inside the clone.
+recipient.txt
+recipients.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md
+
+Guidance for AI agents and new contributors working on this repository.
+
+## What this is
+
+Minimal bash tooling that streams incremental btrfs snapshots to S3, encrypted client-side:
+
+- `stream_backup.sh` — snapshot, then `btrfs send | lz4 | mbuffer | split --filter 'age | aws s3 cp'`
+- `restore_backup.sh` — walks the S3 layout and feeds chunks to `lz4 -d | btrfs receive`
+- `check_deps.sh` — dependency check, executed by both scripts
+- `tests/` — mock-based test suite (`./tests/run.sh`)
+- `examples/` — reference crontab, IAM policy, CloudFormation lifecycle-cleanup stack
+
+Design goal (see README): **small and auditable beats featureful**. No custom file formats, no
+metadata database — all state lives in btrfs snapshot naming on disk and S3 key naming
+conventions. Keep it that way: plain bash, and no new runtime dependencies without a good reason.
+
+## Invariants — do not break
+
+These are load-bearing ABI between the backup script, the restore script, and backups already
+sitting in users' buckets:
+
+1. **S3 key layout**: `s3://BUCKET/PREFIX/EPOCH/<unix-seconds>_<hex-salt>/` containing chunks named
+   by `split` (`x` prefix, 4-letter alphabetic suffix: `xaaaa`, `xaaab`, …) plus
+   `snapshot_info.dat`. `restore_backup.sh` enumerates chunks by generating those names rather than
+   listing the bucket, so if the backup's `split` flags change, the restore walk must change in
+   lockstep. Any format change (compression, encryption, chunking) is only allowed under a **new
+   epoch** (README design rule).
+2. **Completion-marker-last**: `snapshot_info.dat` is uploaded only after every chunk, and restore
+   treats a sequence as valid only if that marker exists and decrypts. Never upload it earlier, and
+   never make restore trust a sequence without it. It is also uploaded without `--storage-class`, so
+   it stays in STANDARD and can be read without a Glacier thaw.
+3. **Local snapshot state is the incremental chain**: the newest snapshot under
+   `${SUBV}/.stream_backup_<EPOCH>/` is the next run's `btrfs send -p` parent. A snapshot must never
+   become eligible as a parent unless its own upload completed — otherwise restore skips its
+   markerless sequence and every later increment fails with "cannot find parent subvolume", while
+   the backups keep reporting success.
+4. **Stream purity**: stdout of the backup pipeline IS the backup. Diagnostics go to stderr, never
+   to the stdout of any pipeline stage. Merging stderr into the stream corrupted real backups once
+   already (a130925, reverted in b131551).
+5. **Least-privilege IAM is a feature**: the backup identity has `s3:PutObject` only — no List, no
+   Delete — and unguessable salted key names are the anti-overwrite control. Don't add anything to
+   the backup path that needs broader permission; `stream_backup.sh` deliberately *warns* at runtime
+   if listing turns out to work.
+6. **Exit codes are a monitoring API**: 0 success, 1 usage error, 2 failure after the snapshot was
+   created, 3 missing dependency. Users alert on these, so keep them stable, document any addition
+   in the README table, and never let a partial failure exit 0.
+
+## Shell facts this code depends on
+
+- `$PIPESTATUS` unindexed expands to element `[0]` only. Check the whole array
+  (`STATUS=("${PIPESTATUS[@]}")`) or rely on `set -o pipefail`.
+- `trap ERR` fires only when the *last* stage of a pipeline fails, unless `pipefail` is set. Do not
+  add `set -E`: with `errtrace` the ERR trap is inherited by command substitutions, and the cleanup
+  handler would run inside subshells.
+- GNU `split --filter` runs the filter through `$SHELL -c`, not through the script's own
+  interpreter, so the ambient `$SHELL` decides how the filter behaves. The filter runs as root:
+  prefer passing values into it through the environment over interpolating them into its text.
+- `$SHELL` is the login-shell variable, not the running interpreter. `$BASH_VERSION` is.
+- These scripts run as root and delete subvolumes. Quote every expansion.
+
+## Working on this repo
+
+- **Run `./tests/run.sh`** before and after any change. It stubs every external command (`aws`,
+  `btrfs`, `age`, `lz4`, `mbuffer`, `openssl`, `date`) on `PATH`, so it needs neither a btrfs
+  filesystem nor an AWS account, and it re-executes itself under `unshare -r` to satisfy the root
+  check. `./tests/run.sh <substring>` runs a subset.
+- Tests assert **exit status *and* resulting state** (which keys were uploaded, in what order, and
+  which snapshots survive). The bug class this project has to defend against is "reported success,
+  wrong state", which an exit-code-only assertion cannot catch.
+- Never run the real scripts against a real filesystem or real AWS while developing.
+- The mocks cannot cover btrfs's own semantics — how snapshot paths are reported for the various
+  mount layouts, or the top-level subvolume (id 5). Verify anything that depends on those against a
+  real btrfs filesystem.
+- Run `shellcheck` on anything you modify.
+- Documentation is part of the product: the README's exit-code table and security guidance, and
+  everything in `examples/`, are the reference deployment. Change them in the same commit as the
+  behaviour they describe.
+- `examples/aws/expire-old-backups.cfn.yaml`'s Lambda **replaces** the bucket's entire lifecycle
+  configuration on every run — keep that in mind before adding lifecycle advice anywhere else.
+- Commit style: short imperative subject lines, no prefixes; PRs are squash-merged with `(#N)`
+  appended.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+#
+# Test suite for stream_backup.sh and restore_backup.sh.
+#
+# Every external command the scripts call is replaced by a stub in tests/stubs,
+# so no btrfs filesystem and no AWS account are needed.  The stubs record what
+# they were asked to do in ${LOG}, and store "uploaded" objects under ${S3ROOT},
+# which lets a backup produced here be replayed through the restore script.
+#
+# The scripts refuse to run as anything but root, so the suite re-executes
+# itself in a user namespace where it is root.
+#
+# Usage: ./tests/run.sh [name-substring]
+
+if [ "${EUID}" -ne 0 ]; then
+  if command -v unshare >/dev/null 2>&1 && unshare -r true 2>/dev/null; then
+    exec unshare -r "$0" "$@"
+  fi
+  echo "This suite must run as root; install util-linux for 'unshare -r' or run it as root." >&2
+  exit 1
+fi
+
+TESTS_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+REPO_DIR=$(dirname -- "${TESTS_DIR}")
+FILTER=${1:-}
+
+PASSED=0
+FAILED=0
+FAILURES=()
+CURRENT=""
+
+# ---------------------------------------------------------------- test harness
+
+setup () {
+  WORK=$(mktemp -d)
+  export TEST_SUBV=${WORK}/subv
+  export S3ROOT=${WORK}/s3
+  export LOG=${WORK}/actions.log
+  export BUCKET=bucket
+  export PREFIX=host
+  mkdir -p "${TEST_SUBV}" "${S3ROOT}/${BUCKET}"
+  : >"${LOG}"
+  echo "age1exampleexamplerecipientkey" >"${WORK}/recipients.txt"
+  echo "AGE-SECRET-KEY-EXAMPLE" >"${WORK}/identity.txt"
+  # check_deps.sh refuses to run unless $SHELL names bash, so the suite cannot
+  # run under a zsh or sh login shell without this.
+  export SHELL=/bin/bash
+  unset FAIL_STAGE FAIL_CHUNK FS_PREFIX AWS_LS_OK AWS_LIST_FAIL AWS_ARCHIVED \
+        AWS_HEAD_ERROR AGE_UNDECRYPTABLE NESTED_SUBVOLS STREAM_BYTES TEST_SALT \
+        TEST_NOW
+}
+
+teardown () {
+  [ -n "${WORK}" ] && rm -rf -- "${WORK}"
+}
+
+backup () {
+  PATH="${TESTS_DIR}/stubs:${PATH}" \
+    "${REPO_DIR}/stream_backup.sh" \
+      -r "${WORK}/recipients.txt" -b "${BUCKET}" -p "${PREFIX}" \
+      -s "${TEST_SUBV}" "$@" >"${WORK}/stdout" 2>"${WORK}/stderr"
+}
+
+restore () {
+  PATH="${TESTS_DIR}/stubs:${PATH}" \
+    "${REPO_DIR}/restore_backup.sh" \
+      -i "${WORK}/identity.txt" -b "${BUCKET}" -p "${PREFIX}" "$@" \
+      >"${WORK}/stdout" 2>"${WORK}/stderr"
+}
+
+# Keys uploaded to S3, in the order they were uploaded.
+uploaded () {
+  grep '^UPLOADED: ' "${LOG}" | sed 's|^UPLOADED: ||'
+}
+
+# Everything the stubs recorded, for failure diagnostics.
+actions () {
+  cat "${LOG}"
+}
+
+snapshots () {
+  find "${TEST_SUBV}" -mindepth 2 -maxdepth 2 -type d -path '*/.stream_backup_*' \
+    2>/dev/null | sed "s|${TEST_SUBV}/||" | sort
+}
+
+fail () {
+  FAILED=$((FAILED + 1))
+  FAILURES+=("${CURRENT}")
+  echo "  FAIL: ${CURRENT}"
+  printf '        %s\n' "$@"
+  if [ -s "${WORK}/stderr" ]; then
+    echo "        --- stderr ---"
+    sed 's/^/        /' "${WORK}/stderr"
+  fi
+  if [ -s "${LOG}" ]; then
+    echo "        --- actions ---"
+    sed 's/^/        /' "${LOG}"
+  fi
+}
+
+pass () {
+  PASSED=$((PASSED + 1))
+  echo "  ok: ${CURRENT}"
+}
+
+assert_status () {
+  [ "$1" = "$2" ] && return 0
+  fail "expected exit status $2, got $1"
+  return 1
+}
+
+assert_equal () {
+  [ "$1" = "$2" ] && return 0
+  fail "expected: $2" "actual:   $1"
+  return 1
+}
+
+assert_contains () {
+  case $1 in
+    *"$2"*) return 0 ;;
+  esac
+  fail "expected to find: $2" "in: $1"
+  return 1
+}
+
+run_test () {
+  CURRENT=$1
+  case ${CURRENT} in
+    *"${FILTER}"*) ;;
+    *) return 0 ;;
+  esac
+  setup
+  if "$2"; then pass; fi
+  teardown
+}
+
+# ------------------------------------------------------------ backup: the good path
+
+test_full_backup () {
+  backup -c STANDARD -e first
+  local status=$?
+  assert_status "${status}" 0 || return 1
+
+  local keys
+  keys=$(uploaded)
+  assert_equal "$(printf '%s\n' "${keys}" | head -n1)" \
+               "${BUCKET}/${PREFIX}/first/1_00000000deadbeef/xaaaa" || return 1
+  # The completion marker must be uploaded last: it is what makes the sequence
+  # valid, and restore trusts nothing without it.
+  assert_equal "$(printf '%s\n' "${keys}" | tail -n1)" \
+               "${BUCKET}/${PREFIX}/first/1_00000000deadbeef/snapshot_info.dat" || return 1
+  assert_contains "$(actions)" "SENT: 1 parent=none" || return 1
+  assert_equal "$(snapshots)" ".stream_backup_first/1" || return 1
+  return 0
+}
+
+test_incremental_backup () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  TEST_NOW=2 backup -c STANDARD -e first
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(actions)" "SENT: 2 parent=1" || return 1
+  assert_equal "$(snapshots)" ".stream_backup_first/1
+.stream_backup_first/2" || return 1
+  return 0
+}
+
+test_delete_previous_snapshot () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  TEST_NOW=2 backup -c STANDARD -e first -d
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_equal "$(snapshots)" ".stream_backup_first/2" || return 1
+  return 0
+}
+
+test_new_epoch_is_a_full_backup () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  TEST_NOW=2 backup -c STANDARD -e second -d
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(actions)" "SENT: 2 parent=none" || return 1
+  # -d must not delete across epochs: the other epoch's chain still needs it.
+  assert_equal "$(snapshots)" ".stream_backup_first/1
+.stream_backup_second/2" || return 1
+  return 0
+}
+
+test_branch_from_another_epoch () {
+  backup -c STANDARD -e monthly || { fail "the first backup failed"; return 1; }
+  TEST_NOW=2 backup -c STANDARD -e daily -B monthly -d
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(actions)" "SENT: 2 parent=1" || return 1
+  # -d must not delete the branch parent, which belongs to the other epoch.
+  assert_equal "$(snapshots)" ".stream_backup_daily/2
+.stream_backup_monthly/1" || return 1
+  return 0
+}
+
+test_branch_epoch_missing_is_an_error () {
+  backup -c STANDARD -e daily -B nonexistent
+  assert_status "$?" 1 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "ERROR" || return 1
+  return 0
+}
+
+# --------------------------------------------------------- backup: failures it catches
+
+test_btrfs_send_failure_is_caught () {
+  FAIL_STAGE=send backup -c STANDARD -e first
+  assert_status "$?" 2 || return 1
+  # No completion marker, so restore will skip the sequence.
+  assert_equal "$(uploaded | grep -c snapshot_info.dat)" "0" || return 1
+  # The snapshot must be gone so the next run re-chains from the last good one.
+  assert_equal "$(snapshots)" "" || return 1
+  return 0
+}
+
+test_snapshot_failure_leaves_nothing_behind () {
+  FAIL_STAGE=snapshot backup -c STANDARD -e first
+  assert_status "$?" 1 || return 1
+  assert_equal "$(uploaded)" "" || return 1
+  assert_equal "$(snapshots)" "" || return 1
+  return 0
+}
+
+test_missing_dependency_exits_3 () {
+  PATH="${TESTS_DIR}/stubs:/nonexistent" \
+    "${REPO_DIR}/stream_backup.sh" -r x -b y -p z -e e -c STANDARD -s "${TEST_SUBV}" \
+    >"${WORK}/stdout" 2>"${WORK}/stderr"
+  assert_status "$?" 3 || return 1
+  return 0
+}
+
+test_no_arguments_prints_usage () {
+  PATH="${TESTS_DIR}/stubs:${PATH}" "${REPO_DIR}/stream_backup.sh" \
+    >"${WORK}/stdout" 2>"${WORK}/stderr"
+  assert_status "$?" 1 || return 1
+  assert_contains "$(cat "${WORK}/stdout")" "Usage:" || return 1
+  return 0
+}
+
+test_unknown_subvolume_is_an_error () {
+  backup -c STANDARD -e first -s "${WORK}/nope"
+  assert_status "$?" 1 || return 1
+  return 0
+}
+
+test_warns_when_the_identity_can_list_the_bucket () {
+  AWS_LS_OK=1 backup -c STANDARD -e first
+  assert_status "$?" 0 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "SECURITY WARNING" || return 1
+  return 0
+}
+
+# ------------------------------------------------------------------------ restore
+
+test_restore_replays_every_sequence_in_order () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  TEST_NOW=2 backup -c STANDARD -e first || { fail "the second backup failed"; return 1; }
+  mkdir -p "${WORK}/dest"
+  : >"${LOG}"
+
+  restore -e first -s "${WORK}/dest"
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_equal "$(grep '^RECEIVED: ' "${LOG}" | sed 's|^RECEIVED: ||' | tr '\n' ' ')" "1 2 " || return 1
+  return 0
+}
+
+test_restore_skips_a_sequence_with_no_valid_marker () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  TEST_NOW=2 backup -c STANDARD -e first || { fail "the second backup failed"; return 1; }
+  # Make the last sequence's marker undecryptable, the way a sequence whose
+  # upload was interrupted before the marker looks.
+  printf 'GARBAGE' >"${S3ROOT}/${BUCKET}/${PREFIX}/first/2_00000000deadbeef/snapshot_info.dat"
+  mkdir -p "${WORK}/dest"
+  : >"${LOG}"
+
+  AGE_UNDECRYPTABLE=GARBAGE restore -e first -s "${WORK}/dest"
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_equal "$(grep '^RECEIVED: ' "${LOG}" | sed 's|^RECEIVED: ||' | tr '\n' ' ')" "1 " || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "WARNING" || return 1
+  return 0
+}
+
+test_restore_deletes_previous_snapshots_with_d () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  TEST_NOW=2 backup -c STANDARD -e first || { fail "the second backup failed"; return 1; }
+  mkdir -p "${WORK}/dest"
+  : >"${LOG}"
+
+  restore -e first -s "${WORK}/dest" -d
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_equal "$(ls "${WORK}/dest")" "2" || return 1
+  return 0
+}
+
+test_restore_without_arguments_prints_usage () {
+  PATH="${TESTS_DIR}/stubs:${PATH}" "${REPO_DIR}/restore_backup.sh" \
+    >"${WORK}/stdout" 2>"${WORK}/stderr"
+  assert_status "$?" 1 || return 1
+  assert_contains "$(cat "${WORK}/stdout")" "Usage:" || return 1
+  return 0
+}
+
+# ----------------------------------------------------------------------- run them
+
+echo "Running the backup tests"
+run_test "a full backup uploads chunks then the completion marker" test_full_backup
+run_test "a second backup in the same epoch is incremental"        test_incremental_backup
+run_test "-d deletes the snapshot it chained from"                 test_delete_previous_snapshot
+run_test "a new epoch starts a full backup"                        test_new_epoch_is_a_full_backup
+run_test "-B chains a new epoch from another one"                  test_branch_from_another_epoch
+run_test "-B with no snapshot to branch from fails"                test_branch_epoch_missing_is_an_error
+run_test "a failing btrfs send deletes the new snapshot"           test_btrfs_send_failure_is_caught
+run_test "a failing snapshot leaves nothing behind"                test_snapshot_failure_leaves_nothing_behind
+run_test "a missing dependency exits 3"                            test_missing_dependency_exits_3
+run_test "no arguments prints the usage"                           test_no_arguments_prints_usage
+run_test "an unknown subvolume is an error"                        test_unknown_subvolume_is_an_error
+run_test "a listable bucket raises a security warning"             test_warns_when_the_identity_can_list_the_bucket
+
+echo "Running the restore tests"
+run_test "restore replays every sequence in order"                 test_restore_replays_every_sequence_in_order
+run_test "restore skips a sequence with no valid marker"           test_restore_skips_a_sequence_with_no_valid_marker
+run_test "restore -d keeps only the last snapshot"                 test_restore_deletes_previous_snapshots_with_d
+run_test "restore without arguments prints the usage"              test_restore_without_arguments_prints_usage
+
+echo
+echo "${PASSED} passed, ${FAILED} failed"
+if [ "${FAILED}" -ne 0 ]; then
+  printf 'failed: %s\n' "${FAILURES[@]}"
+  exit 1
+fi

--- a/tests/stubs/age
+++ b/tests/stubs/age
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Stub for age.  Encryption is the identity function so a backup written by the
+# harness can be replayed through the restore script unchanged.
+#
+# Test knobs:
+#   FAIL_STAGE=age FAIL_CHUNK=<name>  fail while encrypting that chunk ($FILE is
+#                                     set by split; "marker" means snapshot_info.dat)
+#   AGE_UNDECRYPTABLE=<key suffix>    make -d fail for objects with that suffix
+
+if [ "$1" = "-d" ]; then
+  # A file, not a variable: the streams are binary.
+  buffer=$(mktemp)
+  trap 'rm -f -- "${buffer}"' EXIT
+  cat >"${buffer}"
+  if [ -n "${AGE_UNDECRYPTABLE}" ] && grep -qaF -- "${AGE_UNDECRYPTABLE}" "${buffer}"; then
+    echo "age: error: no identity matched any of the recipients" >&2
+    exit 1
+  fi
+  cat -- "${buffer}"
+  exit 0
+fi
+
+if [ "${FAIL_STAGE}" = age ] && [ "${FILE:-marker}" = "${FAIL_CHUNK:-marker}" ]; then
+  cat >/dev/null
+  echo "age: error: failed to read recipients file" >&2
+  exit 1
+fi
+
+exec cat

--- a/tests/stubs/aws
+++ b/tests/stubs/aws
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# Stub for the AWS CLI.  Objects live under ${S3ROOT}/<bucket>/<key>.
+#
+# Test knobs:
+#   FAIL_STAGE=aws FAIL_CHUNK=<suffix>  fail an upload whose key ends in <suffix>,
+#                                       after consuming stdin (the shape a real
+#                                       multipart completion failure takes)
+#   AWS_LS_OK=1                         pretend the identity may list the bucket
+#   AWS_LIST_FAIL=1                     make list-objects-v2 fail
+#   AWS_ARCHIVED=<key suffix>           report the object as un-restored DEEP_ARCHIVE
+#   AWS_HEAD_ERROR=<key suffix>         make head-object fail with a non-404 error
+
+log () { [ -n "${LOG}" ] && printf '%s\n' "$*" >>"${LOG}"; return 0; }
+
+service=$1
+shift
+
+case ${service} in
+  s3)
+    action=$1
+    shift
+    case ${action} in
+      cp)
+        src=$1
+        dst=$2
+        if [ "${src}" = "-" ]; then
+          key=${dst#s3://}
+          bucket=${key%%/*}
+          key=${key#*/}
+          mkdir -p -- "${S3ROOT}/${bucket}/$(dirname -- "${key}")"
+          cat >"${S3ROOT}/${bucket}/${key}"
+          if [ "${FAIL_STAGE}" = aws ] && [ -n "${FAIL_CHUNK}" ] \
+             && [ "${key}" != "${key%${FAIL_CHUNK}}" ]; then
+            rm -f -- "${S3ROOT}/${bucket}/${key}"
+            echo "upload failed: An error occurred (AccessDenied)" >&2
+            exit 1
+          fi
+          log "UPLOADED: ${bucket}/${key}"
+          exit 0
+        fi
+        key=${src#s3://}
+        bucket=${key%%/*}
+        key=${key#*/}
+        if [ ! -f "${S3ROOT}/${bucket}/${key}" ]; then
+          echo "fatal error: An error occurred (404) when calling the HeadObject operation" >&2
+          exit 1
+        fi
+        log "DOWNLOADED: ${bucket}/${key}"
+        cat -- "${S3ROOT}/${bucket}/${key}"
+        exit 0
+        ;;
+      ls)
+        [ "${AWS_LS_OK}" = 1 ] && exit 0
+        echo "An error occurred (AccessDenied) when calling the ListObjectsV2 operation" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  s3api)
+    action=$1
+    shift
+    bucket=""
+    key=""
+    prefix=""
+    while [ $# -gt 0 ]; do
+      case $1 in
+        --bucket) bucket=$2; shift 2 ;;
+        --key)    key=$2;    shift 2 ;;
+        --prefix) prefix=$2; shift 2 ;;
+        *)        shift ;;
+      esac
+    done
+    case ${action} in
+      list-objects-v2)
+        if [ "${AWS_LIST_FAIL}" = 1 ]; then
+          echo "An error occurred (NoSuchBucket)" >&2
+          exit 254
+        fi
+        found=0
+        for d in "${S3ROOT}/${bucket}/${prefix}"*/; do
+          [ -d "${d}" ] || continue
+          printf '%s\n' "${prefix}$(basename -- "${d}")/"
+          found=1
+        done
+        [ "${found}" = 0 ] && echo "None"
+        exit 0
+        ;;
+      head-object)
+        if [ -n "${AWS_HEAD_ERROR}" ] && [ "${key}" != "${key%${AWS_HEAD_ERROR}}" ]; then
+          echo "An error occurred (503) when calling the HeadObject operation" >&2
+          exit 254
+        fi
+        if [ ! -f "${S3ROOT}/${bucket}/${key}" ]; then
+          echo "An error occurred (404) when calling the HeadObject operation: Not Found" >&2
+          exit 254
+        fi
+        if [ -n "${AWS_ARCHIVED}" ] && [ "${key}" != "${key%${AWS_ARCHIVED}}" ]; then
+          printf 'DEEP_ARCHIVE\tNone\n'
+        else
+          printf 'STANDARD\tNone\n'
+        fi
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+
+echo "stub aws: unhandled invocation: ${service} $*" >&2
+exit 64

--- a/tests/stubs/btrfs
+++ b/tests/stubs/btrfs
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# Stub for btrfs-progs.  Snapshots are plain directories; a send stream is a
+# short deterministic text blob naming the subvolume and its parent, which is
+# what lets a restore test assert that the right streams were replayed.
+#
+# Test knobs:
+#   TEST_SUBV=<path>       the fake subvolume root
+#   FS_PREFIX=<path>       what 'subvolume show' reports as the filesystem-tree
+#                          path of TEST_SUBV (defaults to its basename)
+#   FAIL_STAGE=send|show|snapshot|delete|receive
+#   NESTED_SUBVOLS=<lines> what 'subvolume list -o' reports
+
+log () { [ -n "${LOG}" ] && printf '%s\n' "$*" >>"${LOG}"; return 0; }
+
+# Strip a leading '--' argument separator.
+args=()
+for a in "$@"; do
+  [ "${a}" = "--" ] && continue
+  args+=("${a}")
+done
+set -- "${args[@]}"
+
+fs_path () {
+  # Filesystem-tree path of $1, the way 'btrfs subvolume show' prints it.
+  local prefix=${FS_PREFIX:-$(basename -- "${TEST_SUBV}")}
+  local rel=${1#"${TEST_SUBV}"}
+  rel=${rel#/}
+  if [ -z "${rel}" ]; then printf '%s\n' "${prefix}"; else printf '%s/%s\n' "${prefix}" "${rel}"; fi
+}
+
+case "$1 $2" in
+  "send "*)
+    shift
+    parent=""
+    while [ $# -gt 1 ]; do
+      [ "$1" = "-p" ] && parent=$2 && shift
+      shift
+    done
+    subvol=$1
+    echo "At subvol ${subvol}" >&2
+    if [ "${FAIL_STAGE}" = send ]; then
+      echo "ERROR: cannot find parent subvolume" >&2
+      exit 1
+    fi
+    log "SENT: $(basename -- "${subvol}") parent=$(basename -- "${parent:-none}")"
+    printf 'BTRFS-STREAM subvol=%s parent=%s\n' \
+      "$(basename -- "${subvol}")" "$(basename -- "${parent:-none}")"
+    head -c "${STREAM_BYTES:-4000}" /dev/zero
+    exit 0
+    ;;
+  "receive "*)
+    shift
+    dest=$1
+    IFS= read -r stream
+    header_read=$?
+    cat >/dev/null
+    if [ "${FAIL_STAGE}" = receive ]; then
+      echo "ERROR: cannot find parent subvolume" >&2
+      exit 1
+    fi
+    case ${header_read}${stream} in
+      0BTRFS-STREAM*) ;;
+      *) echo "ERROR: unexpected end of stream" >&2; exit 1 ;;
+    esac
+    name=${stream#BTRFS-STREAM subvol=}
+    parent=${name#* parent=}
+    name=${name%% *}
+    # An incremental stream can only be received if its parent is already here.
+    if [ "${parent}" != none ] && [ ! -d "${dest}/${parent}" ]; then
+      echo "ERROR: cannot find parent subvolume ${parent}" >&2
+      exit 1
+    fi
+    mkdir -p -- "${dest}/${name}"
+    log "RECEIVED: ${name}"
+    exit 0
+    ;;
+esac
+
+case "$1 $2" in
+  "subvolume snapshot")
+    shift 2
+    [ "$1" = "-r" ] && shift
+    src=$1
+    dst=$2
+    if [ "${FAIL_STAGE}" = snapshot ]; then
+      echo "ERROR: cannot snapshot ${src}: No space left on device" >&2
+      exit 1
+    fi
+    [ -d "${src}" ] || { echo "ERROR: not a subvolume: ${src}" >&2; exit 1; }
+    [ -e "${dst}" ] && { echo "ERROR: target already exists: ${dst}" >&2; exit 1; }
+    mkdir -p -- "${dst}"
+    log "SNAPSHOT: ${dst}"
+    echo "Create a readonly snapshot of '${src}' in '${dst}'"
+    exit 0
+    ;;
+  "subvolume delete")
+    shift 2
+    target=$1
+    if [ "${FAIL_STAGE}" = delete ]; then
+      echo "ERROR: cannot delete '${target}': Device or resource busy" >&2
+      exit 1
+    fi
+    [ -d "${target}" ] || { echo "ERROR: not a subvolume: ${target}" >&2; exit 1; }
+    rm -rf -- "${target}"
+    log "DELETED: ${target}"
+    echo "Delete subvolume (no-commit): '${target}'"
+    exit 0
+    ;;
+  "subvolume show")
+    shift 2
+    target=${1%/}
+    [ -d "${target}" ] || { echo "ERROR: not a subvolume: ${target}" >&2; exit 1; }
+    if [ "${FAIL_STAGE}" = show ]; then
+      echo "ERROR: cannot access '${target}'" >&2
+      exit 1
+    fi
+    fs_path "${target}"
+    printf '\tUUID:\t\t\t11111111-2222-3333-4444-555555555555\n'
+    printf '\tCreation time:\t\t2026-01-01 00:00:00 +0000\n'
+    printf '\tSnapshot(s):\n'
+    for d in "${TEST_SUBV}"/.stream_backup_*/*/; do
+      [ -d "${d}" ] || continue
+      case ${d} in *"/.incomplete/"*) continue ;; esac
+      printf '\t\t\t\t%s\n' "$(fs_path "${d%/}")"
+    done
+    exit 0
+    ;;
+  "subvolume list")
+    printf '%s' "${NESTED_SUBVOLS}"
+    exit 0
+    ;;
+esac
+
+echo "stub btrfs: unhandled invocation: $*" >&2
+exit 64

--- a/tests/stubs/date
+++ b/tests/stubs/date
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Stub for date, so sequence numbers are deterministic and a test can take two
+# backups without waiting a second between them.
+#
+# Test knob:
+#   TEST_NOW=<seconds>   what 'date +%s' reports (default 1)
+
+if [ "$1" = "+%s" ]; then
+  printf '%s\n' "${TEST_NOW:-1}"
+  exit 0
+fi
+
+exec /usr/bin/date "$@"

--- a/tests/stubs/lz4
+++ b/tests/stubs/lz4
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Stub for lz4.  Compression is the identity function.
+#
+# Test knobs:
+#   FAIL_STAGE=lz4     fail while compressing
+#   FAIL_STAGE=lz4d    fail while decompressing
+
+if [ "$1" = "-d" ]; then
+  if [ "${FAIL_STAGE}" = lz4d ]; then
+    cat >/dev/null
+    echo "lz4: corrupted input" >&2
+    exit 1
+  fi
+  exec cat
+fi
+
+if [ "${FAIL_STAGE}" = lz4 ]; then
+  cat >/dev/null
+  echo "lz4: write error" >&2
+  exit 1
+fi
+
+exec cat

--- a/tests/stubs/mbuffer
+++ b/tests/stubs/mbuffer
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Stub for mbuffer.
+#
+# Test knob:
+#   FAIL_STAGE=mbuffer   consume part of the input then die like an OOM kill,
+#                        which gives the downstream stage a clean EOF
+
+if [ "${FAIL_STAGE}" = mbuffer ]; then
+  head -c 100 >/dev/null
+  exit 137
+fi
+
+exec cat

--- a/tests/stubs/openssl
+++ b/tests/stubs/openssl
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Stub for openssl, so key names are deterministic in assertions.
+#
+# Test knob:
+#   FAIL_STAGE=openssl   fail to produce a salt
+
+if [ "$1" = "rand" ]; then
+  if [ "${FAIL_STAGE}" = openssl ]; then
+    echo "openssl: command not available" >&2
+    exit 1
+  fi
+  printf '%s\n' "${TEST_SALT:-00000000deadbeef}"
+  exit 0
+fi
+
+echo "stub openssl: unhandled invocation: $*" >&2
+exit 64

--- a/tests/stubs/sudo
+++ b/tests/stubs/sudo
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# Stub for sudo, which cannot work in the user namespace the suite runs in.
+# The scripts already require root, so running the command directly is faithful.
+
+exec "$@"


### PR DESCRIPTION
First of a series fixing the bugs found in a review of the repo. This one adds no behaviour changes: it is the harness the rest of the series needs.

Every external command (`aws`, `btrfs`, `age`, `lz4`, `mbuffer`, `openssl`, `date`, `sudo`) is replaced by a stub on `PATH`, so the suite needs neither a btrfs filesystem nor an AWS account. The stubs record what they were asked to do and keep "uploaded" objects in a directory, which means a backup taken by a test can be replayed through the restore script, and assertions can cover the resulting state — which keys were uploaded, in what order, which snapshots survive — rather than only the exit status. That matters here because the bug class this project has to defend against is "reported success, wrong state".

The scripts refuse to run as anything but root, so `tests/run.sh` re-executes itself under `unshare -r`. CI runs it as root instead.

The shellcheck job is deliberately left out until the end of the series, so that CI is never red on `main`.

Also commits `AGENTS.md` (guidance for anyone, human or otherwise, working on this) and a `.gitignore` for the age recipients file the example crontab keeps inside the clone.

**Verification:** `./tests/run.sh` — 16 tests, all passing against the current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)