### PR TITLE
Fail the backup when any pipeline stage fails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,9 @@ sitting in users' buckets:
   add `set -E`: with `errtrace` the ERR trap is inherited by command substitutions, and the cleanup
   handler would run inside subshells.
 - GNU `split --filter` runs the filter through `$SHELL -c`, not through the script's own
-  interpreter, so the ambient `$SHELL` decides how the filter behaves. The filter runs as root:
-  prefer passing values into it through the environment over interpolating them into its text.
+  interpreter, so `stream_backup.sh` passes an explicit `SHELL=` to `split` rather than letting the
+  ambient login shell decide how the filter's error handling behaves. The filter runs as root, so
+  its values reach it through the environment instead of being interpolated into its text.
 - `$SHELL` is the login-shell variable, not the running interpreter. `$BASH_VERSION` is.
 - These scripts run as root and delete subvolumes. Quote every expansion.
 

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
 #
+set -o pipefail
+
 if [ "$EUID" -ne 0 ]
   then echo "Please run as root"
   exit 1
 fi
 
 $(dirname "$0")/check_deps.sh || exit 3
+
+# GNU split runs its --filter through $SHELL, which is the login shell of
+# whoever started us and need not even be bash. Pin it to the interpreter
+# running this script so the filter's own error handling behaves predictably.
+SPLIT_SHELL=${BASH}
+if [ ! -x "${SPLIT_SHELL}" ]; then
+  SPLIT_SHELL=$(command -v bash)
+fi
+if [ ! -x "${SPLIT_SHELL}" ]; then
+  echo "command not found: bash (needed by 'split --filter')" >&2
+  exit 3
+fi
 
 DELETE_PREVIOUS=false
 CHUNK_SIZE="512M"
@@ -136,11 +150,16 @@ btrfs subvolume snapshot -r ${SUBV} ${NEW_SNAPSHOT} || exit 1
 trap cleanup ERR
 trap cleanup INT
 
+S3_SEQ_URL="s3://${BUCKET}/${PREFIX}/${EPOCH}/${SEQ_SALTED}"
+export RECIPIENTS_FILE S3_SEQ_URL SCLASS
+
+# The filter is quoted so that the values reach it through the environment
+# rather than being pasted into a command line that runs as root.
 eval ${BTRFS_COMMAND} 2>/dev/null \
 	| lz4 \
 	| mbuffer -m ${CHUNK_SIZE} -q \
-	| split -b ${CHUNK_SIZE} --suffix-length 4 --filter \
-	"age -R ${RECIPIENTS_FILE} | aws s3 cp - s3://${BUCKET}/${PREFIX}/${EPOCH}/${SEQ_SALTED}/\$FILE --storage-class ${SCLASS}; exit \${PIPESTATUS}"
+	| SHELL="${SPLIT_SHELL}" split -b ${CHUNK_SIZE} --suffix-length 4 --filter \
+	'set -o pipefail; age -R "${RECIPIENTS_FILE}" | aws s3 cp - "${S3_SEQ_URL}/${FILE}" --storage-class "${SCLASS}"'
 
 if [ "${PIPESTATUS}" != "0" ]; then
   cleanup

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -178,12 +178,19 @@ rm -f -- "${SEND_LOG}"
 SEND_LOG=""
 
 # We only write the subvolume information to S3 at the end, as a marker of completion of the backup
-# having the subvolume information might help debuging tricky situations
-btrfs subvolume show ${NEW_SNAPSHOT} \
-  | age -R ${RECIPIENTS_FILE} \
-  | aws s3 cp - s3://${BUCKET}/${PREFIX}/${EPOCH}/${SEQ_SALTED}/snapshot_info.dat
+# having the subvolume information might help debuging tricky situations.
+SNAPSHOT_INFO=$(btrfs subvolume show ${NEW_SNAPSHOT})
 
-if [ "${PIPESTATUS}" != "0" ]; then
+if [ -z "${SNAPSHOT_INFO}" ]; then
+  echo "ERROR: btrfs subvolume show ${NEW_SNAPSHOT} returned nothing" >&2
+  cleanup
+fi
+
+if ! printf '%s\n' "${SNAPSHOT_INFO}" \
+  | age -R "${RECIPIENTS_FILE}" \
+  | aws s3 cp - "${S3_SEQ_URL}/snapshot_info.dat"
+then
+  echo "ERROR: could not upload the completion marker for ${SEQ_SALTED}" >&2
   cleanup
 fi
 

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -21,6 +21,7 @@ if [ ! -x "${SPLIT_SHELL}" ]; then
   exit 3
 fi
 
+SEND_LOG=""
 DELETE_PREVIOUS=false
 CHUNK_SIZE="512M"
 SOURCE_EPOCH=""
@@ -103,6 +104,9 @@ fi
 
 function cleanup () {
   echo "Something went wrong, attempting to clean-up temporary files & snapshots" >&2
+  if [ -n "${SEND_LOG}" ]; then
+    rm -f -- "${SEND_LOG}"
+  fi
   btrfs subvolume delete ${NEW_SNAPSHOT}
   exit 2
 }
@@ -150,20 +154,28 @@ btrfs subvolume snapshot -r ${SUBV} ${NEW_SNAPSHOT} || exit 1
 trap cleanup ERR
 trap cleanup INT
 
+SEND_LOG=$(mktemp) || cleanup
+
 S3_SEQ_URL="s3://${BUCKET}/${PREFIX}/${EPOCH}/${SEQ_SALTED}"
 export RECIPIENTS_FILE S3_SEQ_URL SCLASS
 
-# The filter is quoted so that the values reach it through the environment
-# rather than being pasted into a command line that runs as root.
-eval ${BTRFS_COMMAND} 2>/dev/null \
+# stdout is the backup itself, and btrfs send writes progress as well as errors
+# to stderr, so its stderr goes to a file and is shown only on failure.
+if ! eval ${BTRFS_COMMAND} 2>"${SEND_LOG}" \
 	| lz4 \
 	| mbuffer -m ${CHUNK_SIZE} -q \
 	| SHELL="${SPLIT_SHELL}" split -b ${CHUNK_SIZE} --suffix-length 4 --filter \
 	'set -o pipefail; age -R "${RECIPIENTS_FILE}" | aws s3 cp - "${S3_SEQ_URL}/${FILE}" --storage-class "${SCLASS}"'
-
-if [ "${PIPESTATUS}" != "0" ]; then
+then
+  STATUS=("${PIPESTATUS[@]}")
+  echo "ERROR: the backup stream failed (btrfs send=${STATUS[0]} lz4=${STATUS[1]}" \
+       "mbuffer=${STATUS[2]} split, age or aws=${STATUS[3]})" >&2
+  cat -- "${SEND_LOG}" >&2
   cleanup
 fi
+
+rm -f -- "${SEND_LOG}"
+SEND_LOG=""
 
 # We only write the subvolume information to S3 at the end, as a marker of completion of the backup
 # having the subvolume information might help debuging tricky situations

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -254,6 +254,95 @@ test_warns_when_the_identity_can_list_the_bucket () {
   return 0
 }
 
+# --------------------------------------------------- backup: failures mid-upload
+#
+# A failure here must never leave the completion marker in S3: that marker is
+# what tells a restore the sequence is whole.
+
+# A chunk upload that fails only once the whole chunk has been read is the shape
+# a multipart completion failure or an expiring credential takes.
+assert_upload_failure_is_reported () {
+  assert_status "$1" 2 || return 1
+  assert_equal "$(uploaded | grep -c snapshot_info.dat)" "0" || return 1
+  assert_equal "$(snapshots)" "" || return 1
+  return 0
+}
+
+test_failing_chunk_upload_fails_the_backup () {
+  STREAM_BYTES=4000 FAIL_STAGE=aws FAIL_CHUNK=xaaab \
+    backup -c STANDARD -e first -S 1000
+  assert_upload_failure_is_reported "$?" || return 1
+  return 0
+}
+
+test_failing_last_chunk_upload_fails_the_backup () {
+  STREAM_BYTES=4000 FAIL_STAGE=aws FAIL_CHUNK=xaaae \
+    backup -c STANDARD -e first -S 1000
+  assert_upload_failure_is_reported "$?" || return 1
+  return 0
+}
+
+test_failing_encryption_fails_the_backup () {
+  STREAM_BYTES=4000 FAIL_STAGE=age FAIL_CHUNK=xaaab \
+    backup -c STANDARD -e first -S 1000
+  assert_upload_failure_is_reported "$?" || return 1
+  return 0
+}
+
+test_failing_compression_fails_the_backup () {
+  FAIL_STAGE=lz4 backup -c STANDARD -e first
+  assert_upload_failure_is_reported "$?" || return 1
+  return 0
+}
+
+# mbuffer dying once its producers have finished gives split a clean EOF, so the
+# truncated stream looks like a complete one.
+test_a_killed_buffer_fails_the_backup () {
+  STREAM_BYTES=4000 FAIL_STAGE=mbuffer backup -c STANDARD -e first -S 1000
+  assert_upload_failure_is_reported "$?" || return 1
+  return 0
+}
+
+# Here every chunk uploads cleanly and only the marker's encryption fails, with
+# the upload of the resulting nothing succeeding.
+test_failing_marker_encryption_fails_the_backup () {
+  FAIL_STAGE=age backup -c STANDARD -e first
+  assert_status "$?" 2 || return 1
+  assert_equal "$(snapshots)" "" || return 1
+  return 0
+}
+
+test_failing_marker_generation_fails_the_backup () {
+  FAIL_STAGE=show backup -c STANDARD -e first
+  assert_status "$?" 2 || return 1
+  assert_equal "$(uploaded | grep -c snapshot_info.dat)" "0" || return 1
+  return 0
+}
+
+test_the_error_names_the_stage_that_failed () {
+  FAIL_STAGE=lz4 backup -c STANDARD -e first
+  assert_contains "$(cat "${WORK}/stderr")" "lz4=1" || return 1
+  return 0
+}
+
+# btrfs send's diagnostics are the only clue when a send fails, and stdout is
+# the backup itself, so they have to come back on stderr.
+test_a_failing_send_reports_its_error () {
+  FAIL_STAGE=send backup -c STANDARD -e first
+  assert_contains "$(cat "${WORK}/stderr")" "cannot find parent subvolume" || return 1
+  return 0
+}
+
+test_a_successful_backup_is_quiet_about_send () {
+  backup -c STANDARD -e first
+  assert_status "$?" 0 || return 1
+  # "At subvol ..." is normal progress chatter; cron should not see it.
+  case $(cat "${WORK}/stderr") in
+    *"At subvol"*) fail "btrfs send progress leaked to stderr on a good run"; return 1 ;;
+  esac
+  return 0
+}
+
 # ------------------------------------------------------------------------ restore
 
 test_restore_replays_every_sequence_in_order () {
@@ -322,6 +411,18 @@ run_test "a missing dependency exits 3"                            test_missing_
 run_test "no arguments prints the usage"                           test_no_arguments_prints_usage
 run_test "an unknown subvolume is an error"                        test_unknown_subvolume_is_an_error
 run_test "a listable bucket raises a security warning"             test_warns_when_the_identity_can_list_the_bucket
+
+echo "Running the backup failure tests"
+run_test "a failing chunk upload fails the backup"                 test_failing_chunk_upload_fails_the_backup
+run_test "a failing last chunk upload fails the backup"            test_failing_last_chunk_upload_fails_the_backup
+run_test "a failing encryption fails the backup"                   test_failing_encryption_fails_the_backup
+run_test "a failing compression fails the backup"                  test_failing_compression_fails_the_backup
+run_test "a killed buffer fails the backup"                        test_a_killed_buffer_fails_the_backup
+run_test "a failing marker encryption fails the backup"            test_failing_marker_encryption_fails_the_backup
+run_test "a failing marker generation fails the backup"            test_failing_marker_generation_fails_the_backup
+run_test "the error names the stage that failed"                   test_the_error_names_the_stage_that_failed
+run_test "a failing send reports its error"                        test_a_failing_send_reports_its_error
+run_test "a successful backup is quiet about send"                 test_a_successful_backup_is_quiet_about_send
 
 echo "Running the restore tests"
 run_test "restore replays every sequence in order"                 test_restore_replays_every_sequence_in_order

--- a/tests/stubs/btrfs
+++ b/tests/stubs/btrfs
@@ -111,9 +111,15 @@ case "$1 $2" in
     shift 2
     target=${1%/}
     [ -d "${target}" ] || { echo "ERROR: not a subvolume: ${target}" >&2; exit 1; }
+    # Scoped to snapshots so that the subvolume existence check still succeeds:
+    # what this simulates is a failure to generate the completion marker.
     if [ "${FAIL_STAGE}" = show ]; then
-      echo "ERROR: cannot access '${target}'" >&2
-      exit 1
+      case ${target} in
+        *"/.stream_backup_"*)
+          echo "ERROR: cannot access '${target}'" >&2
+          exit 1
+          ;;
+      esac
     fi
     fs_path "${target}"
     printf '\tUUID:\t\t\t11111111-2222-3333-4444-555555555555\n'


### PR DESCRIPTION
**Severity: critical — these are the cases where a backup reported success and could not have been restored.**

Three separate holes, all from the same root cause: unindexed `${PIPESTATUS}` expands to element `[0]` only.

1. **A failed chunk upload was invisible.** The `split --filter` ended with `exit ${PIPESTATUS}`, which returned `age`'s status and never the status of the `aws s3 cp` it was piped into. An upload that fails after reading its chunk — multipart completion rejected after retries, credentials expiring during a long Deep Archive run, or any failure on a final chunk small enough to fit in the pipe buffer — left `split`, and so the whole backup, reporting success. The completion marker was then uploaded on top, which is what makes restore trust the sequence.

   Which stage got hidden depended on the ambient `$SHELL`, because that is what `split` runs the filter with. It is now pinned to the bash running the script, and `set -o pipefail` inside the filter reports either stage.

2. **`lz4` and `mbuffer` were never looked at.** The checks after the pipeline read `"${PIPESTATUS}"`, i.e. `btrfs send`. An `mbuffer` killed after its producers have finished — it holds up to a whole chunk in memory, so it is a good OOM-killer candidate — gives `split` a clean EOF, so a truncated stream uploaded and the run exited 0. `pipefail` now makes such a failure abort, and the whole array is read so the message says which stage it was.

3. **The completion marker could be empty.** Same check, same problem: if `age` failed while the upload succeeded, an empty `snapshot_info.dat` became the marker. Restore skips a sequence whose marker will not decrypt, so the chain broke there even though every chunk was fine. The information is now generated and checked before the upload starts.

Also: `btrfs send`'s diagnostics were discarded, leaving nothing to explain a failure. They cannot go to stdout — that is the backup itself, and merging them corrupted real backups once already (a130925, reverted in b131551) — so they are kept aside and printed to stderr only when the backup fails. A good run stays as quiet as before.

This is what commit 62153c4 ("Check each piped command") set out to do.

**Verification:** ten new tests inject a failure into each stage and assert the run fails, no marker is uploaded, and the snapshot is deleted. Six of them fail against the previous code. Suite: 26 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)