### PR TITLE
Detect the running interpreter instead of $SHELL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ These scripts rely on well known command line tools and the AWS CLI:
 * sed
 * age (or [rage](https://github.com/str4d/rage/) symlinked to `age` binary in PATH)
 * btrfs-tools
+* openssl
 
 # Design
 Rather than dealing with the complexity of custom file formats and metadata files, we use exclusively the state managed by btrfs-tools and file name conventions on S3.

--- a/check_deps.sh
+++ b/check_deps.sh
@@ -28,8 +28,3 @@ if ! command -v btrfs &> /dev/null; then
   echo "command not found: btrfs"
   exit 3
 fi
-
-if [ "$(basename $SHELL)" != "bash" ]
-  then echo "Please run in bash"
-  exit 1
-fi

--- a/check_deps.sh
+++ b/check_deps.sh
@@ -1,30 +1,8 @@
 #!/bin/bash
 
-if ! command -v age &> /dev/null; then
-  echo "command not found: age"
-  exit 3
-fi
-if ! command -v aws &> /dev/null; then
-  echo "command not found: aws"
-  exit 3
-fi
-if ! command -v lz4 &> /dev/null; then
-  echo "command not found: lz4"
-  exit 3
-fi
-if ! command -v mbuffer &> /dev/null; then
-  echo "command not found: mbuffer"
-  exit 3
-fi
-if ! command -v split &> /dev/null; then
-  echo "command not found: split"
-  exit 3
-fi
-if ! command -v sed &> /dev/null; then
-  echo "command not found: sed"
-  exit 3
-fi
-if ! command -v btrfs &> /dev/null; then
-  echo "command not found: btrfs"
-  exit 3
-fi
+for cmd in age aws lz4 mbuffer split sed btrfs openssl; do
+  if ! command -v "${cmd}" &> /dev/null; then
+    echo "command not found: ${cmd}" >&2
+    exit 3
+  fi
+done

--- a/examples/crontabs/daily-and-monthly.txt
+++ b/examples/crontabs/daily-and-monthly.txt
@@ -10,6 +10,10 @@
 # commands with https://habilis.net/cronic/ to avoid sending emails on success
 #
 
+# cron's default PATH is short: it usually has neither /usr/local/bin, where
+# the AWS CLI and age tend to live, nor /usr/sbin, where btrfs does.
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 BUCKET=your-s3-bucket-name
 PREFIX=s3-prefix-to-identify-backup-in-bucket
 SUBVOLUME=/path/to/mounted/btrfs/subvolume
@@ -22,7 +26,7 @@ SUBVOLUME=/path/to/mounted/btrfs/subvolume
 # |  |  |  |  |
 
 # Do a montly scrub, towards the end of the month
-0 21 27    *   *  btrfs scrub start -B /mnt/BIG/
+0 21 27    *   *  btrfs scrub start -B ${SUBVOLUME}
 
 # Every month, perform an incremental backup relative to the previous month.
 # In January, it will start a new epoch automatically

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 #
+# Before anything else: the shebang can be bypassed with "sh restore_backup.sh",
+# and everything below assumes bash, starting with $EUID.
+if [ -z "${BASH_VERSION}" ]; then
+  echo "Please run with bash" >&2
+  exit 3
+fi
+
 if [ "$EUID" -ne 0 ]
   then echo "Please run as root"
   exit 1

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 #
+# Before anything else: the shebang can be bypassed with "sh stream_backup.sh",
+# and everything below assumes bash, starting with $EUID.
+if [ -z "${BASH_VERSION}" ]; then
+  echo "Please run with bash" >&2
+  exit 3
+fi
+
 set -o pipefail
 
 if [ "$EUID" -ne 0 ]

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -124,7 +124,14 @@ aws s3 ls s3://${BUCKET}/${PREFIX} >/dev/null 2>&1 \
 SEQ=$(date +%s)
 
 # Salting the file names in S3 is important as to prevent malevolent overwriting
-SEQ_SALTED=${SEQ}_$(openssl rand -hex 8)
+SALT=$(openssl rand -hex 8)
+
+if [ -z "${SALT}" ]; then
+  echo "ERROR: could not generate a random salt for the object names" >&2
+  exit 1
+fi
+
+SEQ_SALTED=${SEQ}_${SALT}
 
 SUBV_INFO=$(btrfs subvolume show ${SUBV})
 SUBV_PREFIX=$(echo "${SUBV_INFO}" | head -n1)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -42,9 +42,8 @@ setup () {
   : >"${LOG}"
   echo "age1exampleexamplerecipientkey" >"${WORK}/recipients.txt"
   echo "AGE-SECRET-KEY-EXAMPLE" >"${WORK}/identity.txt"
-  # check_deps.sh refuses to run unless $SHELL names bash, so the suite cannot
-  # run under a zsh or sh login shell without this.
-  export SHELL=/bin/bash
+  # What cron sets, and therefore what the scripts have to cope with.
+  export SHELL=/bin/sh
   unset FAIL_STAGE FAIL_CHUNK FS_PREFIX AWS_LS_OK AWS_LIST_FAIL AWS_ARCHIVED \
         AWS_HEAD_ERROR AGE_UNDECRYPTABLE NESTED_SUBVOLS STREAM_BYTES TEST_SALT \
         TEST_NOW
@@ -233,6 +232,71 @@ test_missing_dependency_exits_3 () {
   return 0
 }
 
+# systemd timers pass no SHELL at all, and cron passes /bin/sh: neither must
+# stop a backup, and neither must change how the split filter behaves.
+test_backup_works_without_a_shell_variable () {
+  env -u SHELL PATH="${TESTS_DIR}/stubs:${PATH}" \
+    TEST_SUBV="${TEST_SUBV}" S3ROOT="${S3ROOT}" LOG="${LOG}" \
+    "${REPO_DIR}/stream_backup.sh" \
+      -r "${WORK}/recipients.txt" -b "${BUCKET}" -p "${PREFIX}" \
+      -s "${TEST_SUBV}" -c STANDARD -e first \
+    >"${WORK}/stdout" 2>"${WORK}/stderr"
+  assert_status "$?" 0 || return 1
+  assert_equal "$(uploaded | tail -n1)" \
+               "${BUCKET}/${PREFIX}/first/1_00000000deadbeef/snapshot_info.dat" || return 1
+  return 0
+}
+
+test_running_under_a_non_bash_shell_is_refused () {
+  local shell=""
+  local candidate
+  for candidate in dash ash sh; do
+    command -v "${candidate}" >/dev/null 2>&1 || continue
+    [ -z "$("${candidate}" -c 'echo ${BASH_VERSION}' 2>/dev/null)" ] || continue
+    shell=${candidate}
+    break
+  done
+  if [ -z "${shell}" ]; then
+    echo "  (skipped, every available sh is bash): ${CURRENT}"
+    return 1
+  fi
+  PATH="${TESTS_DIR}/stubs:${PATH}" "${shell}" "${REPO_DIR}/stream_backup.sh" \
+    >"${WORK}/stdout" 2>"${WORK}/stderr"
+  assert_status "$?" 3 || return 1
+  return 0
+}
+
+# check_deps.sh only uses shell builtins, so it can be run with a PATH holding
+# nothing but the stubs, which is the only way to make a command truly absent.
+test_check_deps_reports_a_missing_openssl () {
+  local bin="${WORK}/bin"
+  mkdir -p "${bin}"
+  local stub
+  for stub in "${TESTS_DIR}"/stubs/*; do
+    [ "$(basename -- "${stub}")" = openssl ] && continue
+    ln -s "${stub}" "${bin}/"
+  done
+  # The tools with no stub of their own still have to be findable.
+  local real
+  for real in split sed; do
+    ln -s "$(command -v "${real}")" "${bin}/"
+  done
+  PATH="${bin}" "${REPO_DIR}/check_deps.sh" >"${WORK}/stdout" 2>"${WORK}/stderr"
+  assert_status "$?" 3 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "openssl" || return 1
+  return 0
+}
+
+# Without a salt the object names become guessable, which is the whole of the
+# defence against a compromised host overwriting earlier backups.
+test_a_failing_salt_stops_the_backup () {
+  FAIL_STAGE=openssl backup -c STANDARD -e first
+  local status=$?
+  [ "${status}" -eq 0 ] && { fail "the backup succeeded without a salt"; return 1; }
+  assert_equal "$(uploaded)" "" || return 1
+  return 0
+}
+
 test_no_arguments_prints_usage () {
   PATH="${TESTS_DIR}/stubs:${PATH}" "${REPO_DIR}/stream_backup.sh" \
     >"${WORK}/stdout" 2>"${WORK}/stderr"
@@ -408,6 +472,10 @@ run_test "-B with no snapshot to branch from fails"                test_branch_e
 run_test "a failing btrfs send deletes the new snapshot"           test_btrfs_send_failure_is_caught
 run_test "a failing snapshot leaves nothing behind"                test_snapshot_failure_leaves_nothing_behind
 run_test "a missing dependency exits 3"                            test_missing_dependency_exits_3
+run_test "a backup works with no SHELL in the environment"         test_backup_works_without_a_shell_variable
+run_test "running under a non-bash shell is refused"               test_running_under_a_non_bash_shell_is_refused
+run_test "check_deps reports a missing openssl"                    test_check_deps_reports_a_missing_openssl
+run_test "a failing salt stops the backup"                         test_a_failing_salt_stops_the_backup
 run_test "no arguments prints the usage"                           test_no_arguments_prints_usage
 run_test "an unknown subvolume is an error"                        test_unknown_subvolume_is_an_error
 run_test "a listable bucket raises a security warning"             test_warns_when_the_identity_can_list_the_bucket


### PR DESCRIPTION
**Severity: high — the documented deployment never took a backup.**

`check_deps.sh` refused to run unless `$SHELL` named bash. `$SHELL` is the login shell of whoever started the script, not the interpreter running it: cron sets it to `/bin/sh` and systemd timers do not set it at all. The shipped example crontab sets neither, so every scheduled run exited 3 — and the README maps 3 to "a required dependency is not installed", which sends you looking in the wrong place entirely.

It also passed in the case it was meant to catch: `sh stream_backup.sh` from a bash login shell keeps `$SHELL` as bash, and the body then runs under `sh`.

The interpreter check now lives in the scripts themselves, as `[ -z "${BASH_VERSION}" ]`, before the first line that assumes bash. `split --filter` no longer depends on the ambient `$SHELL` either, since the previous PR pins one.

Ordering note: this PR is what turns cron backups back on, so it deliberately sits after the pipeline-status fixes rather than before them.

Also here:
- **openssl** was neither in the dependency check nor the README, yet it generates the salt that makes the S3 object names unguessable. Without it the salt was silently empty and the names became entirely predictable, with the run still exiting 0. It is now checked, and an empty salt is fatal.
- The example crontab gets an explicit `PATH` (cron's default has neither `/usr/local/bin`, where the AWS CLI usually lives, nor `/usr/sbin`, where btrfs does), and its scrub line now points at `${SUBVOLUME}` instead of the path it was copied from.

**Verification:** the suite now runs everything with `SHELL=/bin/sh` as cron does, plus a case with no `SHELL` at all. Every test fails against the previous code under those conditions. Suite: 29 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)