### PR TITLE
Find the parent snapshot by listing the epoch directory

### DIFF
--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -177,14 +177,17 @@ if [ -z "${LAST_SNAPSHOT}" ] && [ -n "${SOURCE_EPOCH}" ]; then
   SNAPSHOT_FROM_OTHER_EPOCH=true
 fi
 
+SEND_ARGS=()
+
 if [ -z "${LAST_SNAPSHOT}" ]; then
   echo "No previous snapshot found for this epoch; making a full backup"
   DELETE_PREVIOUS=false
-  BTRFS_COMMAND="btrfs send ${NEW_SNAPSHOT}"
 else
   PARENT_PATH=${PARENT_DIR}/${LAST_SNAPSHOT}
-  BTRFS_COMMAND="btrfs send -p ${PARENT_PATH} ${NEW_SNAPSHOT}"
+  SEND_ARGS+=(-p "${PARENT_PATH}")
 fi
+
+SEND_ARGS+=("${NEW_SNAPSHOT}")
 
 mkdir -p -- "${EPOCH_DIR}"
 btrfs subvolume snapshot -r "${SUBV}" "${NEW_SNAPSHOT}" || exit 1
@@ -199,7 +202,7 @@ export RECIPIENTS_FILE S3_SEQ_URL SCLASS
 
 # stdout is the backup itself, and btrfs send writes progress as well as errors
 # to stderr, so its stderr goes to a file and is shown only on failure.
-if ! eval ${BTRFS_COMMAND} 2>"${SEND_LOG}" \
+if ! btrfs send "${SEND_ARGS[@]}" 2>"${SEND_LOG}" \
 	| lz4 \
 	| mbuffer -m ${CHUNK_SIZE} -q \
 	| SHELL="${SPLIT_SHELL}" split -b ${CHUNK_SIZE} --suffix-length 4 --filter \

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -114,8 +114,31 @@ function cleanup () {
   if [ -n "${SEND_LOG}" ]; then
     rm -f -- "${SEND_LOG}"
   fi
-  btrfs subvolume delete ${NEW_SNAPSHOT}
+  btrfs subvolume delete "${NEW_SNAPSHOT}"
   exit 2
+}
+
+# Name of the newest snapshot in a snapshot directory, or nothing if it holds
+# none. Our snapshots are named after the second they were taken in, so anything
+# that is not a plain number was not put there by this script.
+function latest_snapshot () {
+  local dir=$1
+  local path name newest=""
+
+  [ -d "${dir}" ] || return 0
+
+  for path in "${dir}"/*; do
+    name=${path##*/}
+    case ${name} in
+      ''|*[!0-9]*) continue ;;
+    esac
+    btrfs subvolume show "${path}" >/dev/null 2>&1 || continue
+    if [ -z "${newest}" ] || [ "${name}" -gt "${newest}" ]; then
+      newest=${name}
+    fi
+  done
+
+  printf '%s\n' "${newest}"
 }
 
 aws s3 ls s3://${BUCKET}/${PREFIX} >/dev/null 2>&1 \
@@ -133,37 +156,38 @@ fi
 
 SEQ_SALTED=${SEQ}_${SALT}
 
-SUBV_INFO=$(btrfs subvolume show ${SUBV})
-SUBV_PREFIX=$(echo "${SUBV_INFO}" | head -n1)
-
-if [ -z "${SUBV_PREFIX}" ]; then
+if ! btrfs subvolume show "${SUBV}" >/dev/null 2>&1; then
   echo "Subvolume not found" >&2
   exit 1
 fi
 
-SNAPSHOTS=$(echo "${SUBV_INFO}" | grep -o "${SUBV_PREFIX}/.stream_backup_${EPOCH}.*")
-NEW_SNAPSHOT=${SUBV}/.stream_backup_${EPOCH}/${SEQ}
+EPOCH_DIR=${SUBV%/}/.stream_backup_${EPOCH}
+NEW_SNAPSHOT=${EPOCH_DIR}/${SEQ}
 
-if [ -z "${SNAPSHOTS}" ] && [ ! -z "${SOURCE_EPOCH}" ]; then
-  SNAPSHOTS=$(echo "${SUBV_INFO}" | grep -o "${SUBV_PREFIX}/.stream_backup_${SOURCE_EPOCH}.*")
-  if [ -z ${SNAPSHOTS} ]; then
+PARENT_DIR=${EPOCH_DIR}
+LAST_SNAPSHOT=$(latest_snapshot "${EPOCH_DIR}")
+
+if [ -z "${LAST_SNAPSHOT}" ] && [ -n "${SOURCE_EPOCH}" ]; then
+  PARENT_DIR=${SUBV%/}/.stream_backup_${SOURCE_EPOCH}
+  LAST_SNAPSHOT=$(latest_snapshot "${PARENT_DIR}")
+  if [ -z "${LAST_SNAPSHOT}" ]; then
     echo "ERROR: Neither the current epoch nor the branch epoch has an existing snapshot" >&2
     exit 1
-  else
-    SNAPSHOT_FROM_OTHER_EPOCH=true
   fi
+  SNAPSHOT_FROM_OTHER_EPOCH=true
 fi
-if [ -z "${SNAPSHOTS}" ]; then
+
+if [ -z "${LAST_SNAPSHOT}" ]; then
   echo "No previous snapshot found for this epoch; making a full backup"
   DELETE_PREVIOUS=false
   BTRFS_COMMAND="btrfs send ${NEW_SNAPSHOT}"
 else
-  LAST_SNAPSHOT=$(echo "${SNAPSHOTS}" | tail -n1)
-  BTRFS_COMMAND="btrfs send -p ${SUBV%%${SUBV_PREFIX}*}${LAST_SNAPSHOT} ${NEW_SNAPSHOT}"
+  PARENT_PATH=${PARENT_DIR}/${LAST_SNAPSHOT}
+  BTRFS_COMMAND="btrfs send -p ${PARENT_PATH} ${NEW_SNAPSHOT}"
 fi
 
-mkdir ${SUBV}/.stream_backup_${EPOCH}/ 2>&1 || true
-btrfs subvolume snapshot -r ${SUBV} ${NEW_SNAPSHOT} || exit 1
+mkdir -p -- "${EPOCH_DIR}"
+btrfs subvolume snapshot -r "${SUBV}" "${NEW_SNAPSHOT}" || exit 1
 
 trap cleanup ERR
 trap cleanup INT
@@ -193,7 +217,7 @@ SEND_LOG=""
 
 # We only write the subvolume information to S3 at the end, as a marker of completion of the backup
 # having the subvolume information might help debuging tricky situations.
-SNAPSHOT_INFO=$(btrfs subvolume show ${NEW_SNAPSHOT})
+SNAPSHOT_INFO=$(btrfs subvolume show "${NEW_SNAPSHOT}")
 
 if [ -z "${SNAPSHOT_INFO}" ]; then
   echo "ERROR: btrfs subvolume show ${NEW_SNAPSHOT} returned nothing" >&2
@@ -213,8 +237,8 @@ fi
 # * If there is a previous snapshot in the first place
 # * If the snapshot is not from another epoch
 if     [ "${DELETE_PREVIOUS}" == true ] \
-    && [ ! -z "${LAST_SNAPSHOT}" ] \
+    && [ -n "${LAST_SNAPSHOT}" ] \
     && [ ${SNAPSHOT_FROM_OTHER_EPOCH} == false ]; then
-  btrfs subvolume delete ${SUBV%%${SUBV_PREFIX}*}${LAST_SNAPSHOT}
+  btrfs subvolume delete "${PARENT_PATH}"
 fi
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -79,7 +79,7 @@ actions () {
 
 snapshots () {
   find "${TEST_SUBV}" -mindepth 2 -maxdepth 2 -type d -path '*/.stream_backup_*' \
-    2>/dev/null | sed "s|${TEST_SUBV}/||" | sort
+    2>/dev/null | sed "s|${TEST_SUBV}/||" | LC_ALL=C sort
 }
 
 fail () {
@@ -201,6 +201,49 @@ test_branch_epoch_missing_is_an_error () {
   backup -c STANDARD -e daily -B nonexistent
   assert_status "$?" 1 || return 1
   assert_contains "$(cat "${WORK}/stderr")" "ERROR" || return 1
+  return 0
+}
+
+# --------------------------------------------------------------- backup: layouts
+#
+# 'btrfs subvolume show' reports a subvolume's path relative to the root of the
+# filesystem, which has nothing to do with where it is mounted. These are the
+# layouts where the two differ.
+
+# What "mount -o subvol=@home" gives you: mounted at /home, called @home inside
+# the filesystem.
+test_incremental_backup_on_a_subvol_mount () {
+  FS_PREFIX="@home" backup -c STANDARD -e first \
+    || { fail "the first backup failed"; return 1; }
+  FS_PREFIX="@home" TEST_NOW=2 backup -c STANDARD -e first
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(actions)" "SENT: 2 parent=1" || return 1
+  return 0
+}
+
+# The top-level subvolume, id 5, whose path is reported as "/".
+test_incremental_backup_of_the_top_level_subvolume () {
+  FS_PREFIX="/" backup -c STANDARD -e first \
+    || { fail "the first backup failed"; return 1; }
+  FS_PREFIX="/" TEST_NOW=2 backup -c STANDARD -e first -d
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(actions)" "SENT: 2 parent=1" || return 1
+  # -d has to work here too, or snapshots pile up until the disk fills.
+  assert_equal "$(snapshots)" ".stream_backup_first/2" || return 1
+  return 0
+}
+
+# One epoch name being a prefix of another must not make them share snapshots.
+test_epoch_names_that_share_a_prefix_stay_separate () {
+  backup -c STANDARD -e daily-2026-10 || { fail "the first backup failed"; return 1; }
+  TEST_NOW=2 backup -c STANDARD -e daily-2026-1 -d
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(actions)" "SENT: 2 parent=none" || return 1
+  assert_equal "$(snapshots)" ".stream_backup_daily-2026-1/2
+.stream_backup_daily-2026-10/1" || return 1
   return 0
 }
 
@@ -469,6 +512,9 @@ run_test "-d deletes the snapshot it chained from"                 test_delete_p
 run_test "a new epoch starts a full backup"                        test_new_epoch_is_a_full_backup
 run_test "-B chains a new epoch from another one"                  test_branch_from_another_epoch
 run_test "-B with no snapshot to branch from fails"                test_branch_epoch_missing_is_an_error
+run_test "incrementals work on a subvol= mount"                    test_incremental_backup_on_a_subvol_mount
+run_test "incrementals work on the top-level subvolume"            test_incremental_backup_of_the_top_level_subvolume
+run_test "epoch names sharing a prefix stay separate"              test_epoch_names_that_share_a_prefix_stay_separate
 run_test "a failing btrfs send deletes the new snapshot"           test_btrfs_send_failure_is_caught
 run_test "a failing snapshot leaves nothing behind"                test_snapshot_failure_leaves_nothing_behind
 run_test "a missing dependency exits 3"                            test_missing_dependency_exits_3

--- a/tests/stubs/btrfs
+++ b/tests/stubs/btrfs
@@ -22,11 +22,19 @@ done
 set -- "${args[@]}"
 
 fs_path () {
-  # Filesystem-tree path of $1, the way 'btrfs subvolume show' prints it.
+  # Filesystem-tree path of $1, the way 'btrfs subvolume show' prints it: the
+  # path relative to the root of the filesystem, which for the top-level
+  # subvolume (id 5) is reported as "/".
   local prefix=${FS_PREFIX:-$(basename -- "${TEST_SUBV}")}
   local rel=${1#"${TEST_SUBV}"}
   rel=${rel#/}
-  if [ -z "${rel}" ]; then printf '%s\n' "${prefix}"; else printf '%s/%s\n' "${prefix}" "${rel}"; fi
+  if [ -z "${rel}" ]; then
+    printf '%s\n' "${prefix}"
+  elif [ "${prefix}" = "/" ]; then
+    printf '%s\n' "${rel}"
+  else
+    printf '%s/%s\n' "${prefix}" "${rel}"
+  fi
 }
 
 case "$1 $2" in
@@ -41,6 +49,10 @@ case "$1 $2" in
     echo "At subvol ${subvol}" >&2
     if [ "${FAIL_STAGE}" = send ]; then
       echo "ERROR: cannot find parent subvolume" >&2
+      exit 1
+    fi
+    if [ -n "${parent}" ] && [ ! -d "${parent}" ]; then
+      echo "ERROR: cannot find parent subvolume ${parent}" >&2
       exit 1
     fi
     log "SENT: $(basename -- "${subvol}") parent=$(basename -- "${parent:-none}")"


### PR DESCRIPTION
**Severity: high — incrementals were impossible on the mount layout most distributions use.**

The parent's path was rebuilt by stripping the filesystem-tree path that `btrfs subvolume show` reports off the end of the mount path. That only works when one is a suffix of the other, which holds for a filesystem mounted at its top level — `/mnt/BIG/data` with an internal path of `data` — and fails for the `subvol=` mounts distributions use. On `/home` mounted as `subvol=@home` it produced `/home@home/...`, so every incremental after the first full backup failed, every night, with `btrfs send`'s explanation discarded and only "Something went wrong" reaching the operator. The same broken path was handed to `btrfs subvolume delete`, running as root.

Two more problems in the same code:

- The snapshot list was searched with an unanchored pattern built from the epoch name, so an epoch whose name is a prefix of another — `daily-2026-1` against `daily-2026-10` — could pick up the *other* epoch's snapshot as its parent. The backup then uploads happily, but its parent stream lives under a different prefix in S3, so the epoch cannot be restored on its own.
- For the top-level subvolume, whose path is reported as `/`, nothing ever matched: every run made a full backup and `-d` silently did nothing, so snapshots accumulated until the disk filled.

Our snapshots live in a directory we own, named after the second they were taken in, so the fix is to read that directory instead of reconstructing paths from scraped output. That removes both `${SUBV%%${SUBV_PREFIX}*}` sites at once.

`eval` goes with it: the command was built as a string, so any shell metacharacter in a path was executed as root. An array says what is an argument without needing quoting rules to be right.

**Verification:** three new tests cover a `subvol=` mount, the top-level subvolume, and two epochs sharing a name prefix. All three fail against the previous code. The stubbed `btrfs send` now also refuses a parent path that does not exist, as the real one does — without that, the broken-layout test passed against the broken code. Suite: 32 passing.

**Worth running by hand:** the last PR in this series adds `tests/integration.sh`, which exercises this against a real btrfs filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)