### PR TITLE
Never chain a backup from a snapshot whose upload did not finish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,11 @@ sitting in users' buckets:
    `${SUBV}/.stream_backup_<EPOCH>/` is the next run's `btrfs send -p` parent. A snapshot must never
    become eligible as a parent unless its own upload completed — otherwise restore skips its
    markerless sequence and every later increment fails with "cannot find parent subvolume", while
-   the backups keep reporting success.
+   the backups keep reporting success. This is why a snapshot is taken in
+   `.stream_backup_<EPOCH>/.incomplete/` and moved out only after the completion marker is uploaded:
+   eligibility is expressed by *where* the snapshot is, and the move is a single rename. Its
+   basename never changes, because `btrfs send` puts it in the stream and `btrfs receive` recreates
+   it under that name.
 4. **Stream purity**: stdout of the backup pipeline IS the backup. Diagnostics go to stderr, never
    to the stdout of any pipeline stage. Merging stderr into the stream corrupted real backups once
    already (a130925, reverted in b131551).
@@ -44,8 +48,9 @@ sitting in users' buckets:
    the backup path that needs broader permission; `stream_backup.sh` deliberately *warns* at runtime
    if listing turns out to work.
 6. **Exit codes are a monitoring API**: 0 success, 1 usage error, 2 failure after the snapshot was
-   created, 3 missing dependency. Users alert on these, so keep them stable, document any addition
-   in the README table, and never let a partial failure exit 0.
+   created, 3 missing dependency, 4 the backup succeeded but the tidying up after it did not. Users
+   alert on these, so keep them stable, document any addition in the README table, and never let a
+   partial failure exit 0.
 
 ## Shell facts this code depends on
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Rather than dealing with the complexity of custom file formats and metadata file
 
 As such if you want to change the format (compression, encryption, file container, etc.), please start a new backup _epoch_ so as not to mix the two.
 
+Snapshots live in `.stream_backup_<epoch>/` inside the subvolume, named after the second they were taken in. A new snapshot is created in `.stream_backup_<epoch>/.incomplete/` and only moved next to the others once every chunk *and* the completion marker have reached S3. That is what makes an interrupted backup safe: the next run can only ever chain from a snapshot whose upload finished, because a sequence with no completion marker is skipped when restoring, and anything chained from it could not be restored either. A snapshot found in `.incomplete/` at the start of a run is reported and deleted.
+
 # Return value
 
 It is important that you check the return value of the back-up script for proper monitoring and alerting.
@@ -27,6 +29,7 @@ It is important that you check the return value of the back-up script for proper
 * 1: a "usage" error occured. You used a unrecognised command switch, or referenced a volume or snapshot that does not exist
 * 2: an error occurred after the snapshot was created, **you should pay close attention to these**! The script will have tried to delete the newly created snapshot so that subsequent incremental backups can be made from the last good known state
 * 3: a required dependency is not installed
+* 4: the backup itself completed and is safe in S3, but tidying up afterwards did not. Nothing is at risk and there is nothing to re-run, but snapshots will accumulate on disk until you look into it
 
 # Important security recommendations
 This is all rather common sense, but:

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -29,6 +29,9 @@ if [ ! -x "${SPLIT_SHELL}" ]; then
 fi
 
 SEND_LOG=""
+SNAPSHOT_STAGED=""
+BACKUP_OK=false
+HOUSEKEEPING_FAILED=false
 DELETE_PREVIOUS=false
 CHUNK_SIZE="512M"
 SOURCE_EPOCH=""
@@ -109,12 +112,38 @@ EOF
         exit 1
 fi
 
-function cleanup () {
-  echo "Something went wrong, attempting to clean-up temporary files & snapshots" >&2
+# Runs however the script ends, including on a signal. A snapshot that is still
+# staged is one whose upload did not finish, and the next run must not be able
+# to chain from it, so it goes.
+function on_exit () {
+  local status=$?
+
+  trap - EXIT ERR INT TERM HUP
+
   if [ -n "${SEND_LOG}" ]; then
     rm -f -- "${SEND_LOG}"
   fi
-  btrfs subvolume delete "${NEW_SNAPSHOT}"
+
+  if [ "${BACKUP_OK}" != true ]; then
+    if [ -n "${SNAPSHOT_STAGED}" ] && [ -e "${SNAPSHOT_STAGED}" ]; then
+      echo "Something went wrong, deleting the snapshot this run created" >&2
+      btrfs subvolume delete "${SNAPSHOT_STAGED}" >&2 \
+        || echo "ERROR: could not delete ${SNAPSHOT_STAGED}, remove it by hand" >&2
+      status=2
+    elif [ "${status}" -eq 0 ]; then
+      status=1
+    fi
+  elif [ "${HOUSEKEEPING_FAILED}" == true ]; then
+    status=4
+  else
+    status=0
+  fi
+
+  exit "${status}"
+}
+
+function on_signal () {
+  echo "ERROR: caught SIG$1, aborting" >&2
   exit 2
 }
 
@@ -162,7 +191,12 @@ if ! btrfs subvolume show "${SUBV}" >/dev/null 2>&1; then
 fi
 
 EPOCH_DIR=${SUBV%/}/.stream_backup_${EPOCH}
+# A snapshot is only moved out of here once its upload has completed, so
+# whatever is left in it is unusable, and being in it is what stops
+# latest_snapshot from ever offering it as a parent.
+STAGE_DIR=${EPOCH_DIR}/.incomplete
 NEW_SNAPSHOT=${EPOCH_DIR}/${SEQ}
+SNAPSHOT_STAGED=${STAGE_DIR}/${SEQ}
 
 PARENT_DIR=${EPOCH_DIR}
 LAST_SNAPSHOT=$(latest_snapshot "${EPOCH_DIR}")
@@ -187,15 +221,29 @@ else
   SEND_ARGS+=(-p "${PARENT_PATH}")
 fi
 
-SEND_ARGS+=("${NEW_SNAPSHOT}")
+SEND_ARGS+=("${SNAPSHOT_STAGED}")
 
-mkdir -p -- "${EPOCH_DIR}"
-btrfs subvolume snapshot -r "${SUBV}" "${NEW_SNAPSHOT}" || exit 1
+trap on_exit EXIT
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
+trap 'on_signal HUP' HUP
+trap 'exit 1' ERR
 
-trap cleanup ERR
-trap cleanup INT
+if [ -d "${STAGE_DIR}" ]; then
+  for ORPHAN in "${STAGE_DIR}"/*; do
+    [ -e "${ORPHAN}" ] || continue
+    echo "WARNING: ${ORPHAN} was left behind by an interrupted backup." >&2
+    echo "         Its sequence in S3 was never completed and cannot be restored," >&2
+    echo "         so it cannot be used as a parent. Deleting it." >&2
+    btrfs subvolume delete "${ORPHAN}" >&2 \
+      || echo "WARNING: could not delete ${ORPHAN}, remove it by hand" >&2
+  done
+fi
 
-SEND_LOG=$(mktemp) || cleanup
+mkdir -p -- "${STAGE_DIR}"
+btrfs subvolume snapshot -r "${SUBV}" "${SNAPSHOT_STAGED}" || exit 1
+
+SEND_LOG=$(mktemp) || exit 2
 
 S3_SEQ_URL="s3://${BUCKET}/${PREFIX}/${EPOCH}/${SEQ_SALTED}"
 export RECIPIENTS_FILE S3_SEQ_URL SCLASS
@@ -212,7 +260,7 @@ then
   echo "ERROR: the backup stream failed (btrfs send=${STATUS[0]} lz4=${STATUS[1]}" \
        "mbuffer=${STATUS[2]} split, age or aws=${STATUS[3]})" >&2
   cat -- "${SEND_LOG}" >&2
-  cleanup
+  exit 2
 fi
 
 rm -f -- "${SEND_LOG}"
@@ -220,11 +268,11 @@ SEND_LOG=""
 
 # We only write the subvolume information to S3 at the end, as a marker of completion of the backup
 # having the subvolume information might help debuging tricky situations.
-SNAPSHOT_INFO=$(btrfs subvolume show "${NEW_SNAPSHOT}")
+SNAPSHOT_INFO=$(btrfs subvolume show "${SNAPSHOT_STAGED}")
 
 if [ -z "${SNAPSHOT_INFO}" ]; then
-  echo "ERROR: btrfs subvolume show ${NEW_SNAPSHOT} returned nothing" >&2
-  cleanup
+  echo "ERROR: btrfs subvolume show ${SNAPSHOT_STAGED} returned nothing" >&2
+  exit 2
 fi
 
 if ! printf '%s\n' "${SNAPSHOT_INFO}" \
@@ -232,16 +280,29 @@ if ! printf '%s\n' "${SNAPSHOT_INFO}" \
   | aws s3 cp - "${S3_SEQ_URL}/snapshot_info.dat"
 then
   echo "ERROR: could not upload the completion marker for ${SEQ_SALTED}" >&2
-  cleanup
+  exit 2
 fi
+
+# The sequence is complete in S3, so this snapshot is now a valid parent for the
+# next run and can leave the staging directory.
+mv -T -- "${SNAPSHOT_STAGED}" "${NEW_SNAPSHOT}"
+BACKUP_OK=true
+trap - ERR
+rmdir -- "${STAGE_DIR}" 2>/dev/null
 
 # We delete the snapshot from which we made an incremental backup:
 # * If the user asked for it
 # * If there is a previous snapshot in the first place
 # * If the snapshot is not from another epoch
+# The backup is already safe in S3 by now, so failing here is not fatal.
 if     [ "${DELETE_PREVIOUS}" == true ] \
     && [ -n "${LAST_SNAPSHOT}" ] \
     && [ ${SNAPSHOT_FROM_OTHER_EPOCH} == false ]; then
-  btrfs subvolume delete "${PARENT_PATH}"
+  if ! btrfs subvolume delete "${PARENT_PATH}"; then
+    echo "WARNING: the backup completed, but the snapshot it was made from" >&2
+    echo "         (${PARENT_PATH}) could not be deleted. Snapshots will pile" >&2
+    echo "         up until this is dealt with." >&2
+    HOUSEKEEPING_FAILED=true
+  fi
 fi
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -77,8 +77,16 @@ actions () {
   cat "${LOG}"
 }
 
+# Snapshots that count as complete: named after their sequence number and
+# sitting directly in an epoch directory.
 snapshots () {
   find "${TEST_SUBV}" -mindepth 2 -maxdepth 2 -type d -path '*/.stream_backup_*' \
+    2>/dev/null | sed "s|${TEST_SUBV}/||" | grep -E '/[0-9]+$' | LC_ALL=C sort
+}
+
+# Snapshots still in the staging directory, which no run may chain from.
+staged () {
+  find "${TEST_SUBV}" -mindepth 3 -maxdepth 3 -type d -path '*/.incomplete/*' \
     2>/dev/null | sed "s|${TEST_SUBV}/||" | LC_ALL=C sort
 }
 
@@ -372,6 +380,7 @@ assert_upload_failure_is_reported () {
   assert_status "$1" 2 || return 1
   assert_equal "$(uploaded | grep -c snapshot_info.dat)" "0" || return 1
   assert_equal "$(snapshots)" "" || return 1
+  assert_equal "$(staged)" "" || return 1
   return 0
 }
 
@@ -447,6 +456,82 @@ test_a_successful_backup_is_quiet_about_send () {
   case $(cat "${WORK}/stderr") in
     *"At subvol"*) fail "btrfs send progress leaked to stderr on a good run"; return 1 ;;
   esac
+  return 0
+}
+
+# ------------------------------------------------ backup: snapshots left half-done
+#
+# A snapshot whose upload never finished has no completion marker in S3, so
+# restore skips its sequence. Chaining the next backup from it would therefore
+# break every backup after it, while each of them still reported success.
+
+test_an_orphaned_snapshot_is_not_used_as_a_parent () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  # What a run killed mid-upload leaves behind.
+  mkdir -p "${TEST_SUBV}/.stream_backup_first/.incomplete/5"
+  : >"${LOG}"
+
+  TEST_NOW=6 backup -c STANDARD -e first
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(actions)" "SENT: 6 parent=1" || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "WARNING" || return 1
+  assert_equal "$(staged)" "" || return 1
+  assert_equal "$(snapshots)" ".stream_backup_first/1
+.stream_backup_first/6" || return 1
+  return 0
+}
+
+test_a_terminated_backup_leaves_nothing_behind () {
+  local i=0
+
+  # The backup gets a session of its own so that signalling its process group
+  # cannot touch the test suite; setsid --wait still reports its exit status.
+  (
+    AWS_HANG=1 PGID_FILE="${WORK}/pgid" PATH="${TESTS_DIR}/stubs:${PATH}" \
+      setsid --fork --wait "${REPO_DIR}/stream_backup.sh" \
+        -r "${WORK}/recipients.txt" -b "${BUCKET}" -p "${PREFIX}" \
+        -s "${TEST_SUBV}" -c STANDARD -e first >/dev/null 2>&1
+    echo $? >"${WORK}/status"
+  ) &
+
+  while [ ! -s "${WORK}/pgid" ]; do
+    i=$((i + 1))
+    [ "${i}" -gt 200 ] && { fail "the backup never got as far as uploading"; return 1; }
+    sleep 0.05
+  done
+
+  # systemd signals the whole process group at shutdown, which is what ends the
+  # pipeline and lets the trap run.
+  kill -TERM -"$(cat "${WORK}/pgid")" 2>/dev/null
+
+  i=0
+  while [ ! -f "${WORK}/status" ]; do
+    i=$((i + 1))
+    [ "${i}" -gt 200 ] && { fail "the backup did not exit after SIGTERM"; return 1; }
+    sleep 0.05
+  done
+
+  assert_equal "$(cat "${WORK}/status")" "2" || return 1
+  assert_equal "$(staged)" "" || return 1
+  assert_equal "$(snapshots)" "" || return 1
+  assert_equal "$(uploaded | grep -c snapshot_info.dat)" "0" || return 1
+  return 0
+}
+
+# The backup is safe in S3 by then, so tidying up afterwards must not be able to
+# destroy it, and must not be reported as a failed backup either.
+test_a_failed_tidy_up_keeps_the_backup () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  : >"${LOG}"
+
+  TEST_NOW=2 FAIL_STAGE=delete backup -c STANDARD -e first -d
+  local status=$?
+  assert_status "${status}" 4 || return 1
+  assert_equal "$(uploaded | tail -n1)" \
+               "${BUCKET}/${PREFIX}/first/2_00000000deadbeef/snapshot_info.dat" || return 1
+  assert_equal "$(snapshots)" ".stream_backup_first/1
+.stream_backup_first/2" || return 1
   return 0
 }
 
@@ -537,6 +622,11 @@ run_test "a failing marker generation fails the backup"            test_failing_
 run_test "the error names the stage that failed"                   test_the_error_names_the_stage_that_failed
 run_test "a failing send reports its error"                        test_a_failing_send_reports_its_error
 run_test "a successful backup is quiet about send"                 test_a_successful_backup_is_quiet_about_send
+
+echo "Running the interrupted backup tests"
+run_test "an orphaned snapshot is not used as a parent"            test_an_orphaned_snapshot_is_not_used_as_a_parent
+run_test "a terminated backup leaves nothing behind"               test_a_terminated_backup_leaves_nothing_behind
+run_test "a failed tidy up keeps the backup"                       test_a_failed_tidy_up_keeps_the_backup
 
 echo "Running the restore tests"
 run_test "restore replays every sequence in order"                 test_restore_replays_every_sequence_in_order

--- a/tests/stubs/aws
+++ b/tests/stubs/aws
@@ -24,6 +24,16 @@ case ${service} in
       cp)
         src=$1
         dst=$2
+        # Never returns, and never reads its input, so the whole pipeline stalls
+        # the way a long upload does. Reports the process group it is running
+        # in, which is the one a test has to signal to imitate a shutdown.
+        if [ "${src}" = "-" ] && [ "${AWS_HANG}" = 1 ]; then
+          if [ -n "${PGID_FILE}" ]; then
+            ps -o pgid= -p $$ | tr -d ' ' >"${PGID_FILE}"
+          fi
+          sleep 300
+          exit 0
+        fi
         if [ "${src}" = "-" ]; then
           key=${dst#s3://}
           bucket=${key%%/*}


### PR DESCRIPTION
**Severity: critical — an epoch that reported success every night and could not be restored past the interruption.**

The snapshot was created before the upload started and left in place whatever happened next. `ERR` and `INT` were trapped; `TERM` and `HUP` were not, so a shutdown during a long Deep Archive upload (systemd sends `TERM`) left the snapshot behind while its sequence in S3 had no completion marker.

The next run then chained from that snapshot and exited 0. So did every run after it. But restore skips a sequence with no marker, so `btrfs receive` cannot find the parent of the next one: everything from the interruption onwards is unrestorable, discovered only when you try. With `-d`, the orphan is deleted after the next "successful" run, taking the local evidence with it.

A snapshot is now created in `.stream_backup_<epoch>/.incomplete/` and moved out only once the completion marker has been uploaded. Being usable as a parent is a matter of *where* the snapshot is, and the move is a single rename. Its name does not change, so the send stream and everything already in the bucket are unaffected, and snapshots written by earlier versions are already in the right place — nothing is forced into a new full backup.

The traps now cover `TERM` and `HUP`, and are in place before the snapshot is created. Anything found in `.incomplete/` at the start of a run is reported loudly and deleted: it can never be a valid parent, and the backup identity has no `s3:GetObject`, so the script cannot check whether its sequence completed. Promoting on faith would be the original bug.

Also fixes a smaller one with the same shape: the `ERR` trap stayed armed after the backup was safely in S3, so a failed `btrfs subvolume delete` of the old snapshot ran the cleanup handler and destroyed the snapshot that had just been backed up, reporting failure for a backup that had actually worked. That case now exits **4** — the new code for "the work succeeded, tidying up after it did not" — and leaves the snapshot alone.

One accepted race, documented in the code: a kill in the single-syscall window between the marker upload and the rename leaves a complete sequence whose snapshot is cleaned up later, so two sequences share a parent. Harmless for a plain restore; it breaks a `-d` restore.

**Verification:** three new tests — a leftover snapshot in `.incomplete/`, a real `SIGTERM` to the process group during an upload, and a tidy-up that fails after a good backup. All three fail against the previous code. Suite: 35 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)