### PR TITLE
Check every step of the restore before moving on

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,27 @@ As such if you want to change the format (compression, encryption, file containe
 
 Snapshots live in `.stream_backup_<epoch>/` inside the subvolume, named after the second they were taken in. A new snapshot is created in `.stream_backup_<epoch>/.incomplete/` and only moved next to the others once every chunk *and* the completion marker have reached S3. That is what makes an interrupted backup safe: the next run can only ever chain from a snapshot whose upload finished, because a sequence with no completion marker is skipped when restoring, and anything chained from it could not be restored either. A snapshot found in `.incomplete/` at the start of a run is reported and deleted.
 
-# Return value
+# Return values
 
-It is important that you check the return value of the back-up script for proper monitoring and alerting.
+It is important that you check the return value of these scripts for proper monitoring and alerting.
+
+## stream_backup.sh
 
 * 0: everything went fine
 * 1: a "usage" error occured. You used a unrecognised command switch, or referenced a volume or snapshot that does not exist
 * 2: an error occurred after the snapshot was created, **you should pay close attention to these**! The script will have tried to delete the newly created snapshot so that subsequent incremental backups can be made from the last good known state
 * 3: a required dependency is not installed
 * 4: the backup itself completed and is safe in S3, but tidying up afterwards did not. Nothing is at risk and there is nothing to re-run, but snapshots will accumulate on disk until you look into it
+
+## restore_backup.sh
+
+* 0: every sequence of the epoch was restored
+* 1: a "usage" error, or the epoch could not be listed, or it holds no backup
+* 2: the restore stopped part way. The last snapshot that *was* restored is named at the end of the output, and is the one a new attempt will carry on from
+* 3: a required dependency is not installed
+* 4: the restore stopped because objects are still in Glacier or Deep Archive and have to be copied to S3 Standard first
+
+A restore stops at the first sequence it cannot replay, because every later one is an increment on it.
 
 # Important security recommendations
 This is all rather common sense, but:

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -7,6 +7,8 @@ if [ -z "${BASH_VERSION}" ]; then
   exit 3
 fi
 
+set -o pipefail
+
 if [ "$EUID" -ne 0 ]
   then echo "Please run as root"
   exit 1
@@ -67,45 +69,171 @@ EOF
         exit 1
 fi
 
+RESTORED_SEQ=""
+EXIT_CODE=0
+
 function summarise () {
-  if [ "${PREV_SEQ}" != "" ]; then
-    echo "Last snapshot successfully restored in: ${DEST}/${PREV_SEQ}"
+  if [ -n "${RESTORED_SEQ}" ]; then
+    echo "Last snapshot successfully restored in: ${DEST%/}/${RESTORED_SEQ}"
+  else
+    echo "No snapshot was restored." >&2
   fi
 }
 
-PREV_SEQ=""
+function on_signal () {
+  echo "ERROR: caught SIG$1, aborting" >&2
+  summarise
+  exit 2
+}
 
-trap summarise ERR
-trap summarise INT
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
+trap 'on_signal HUP' HUP
 
-for SEQ_PREFIX in $(aws s3api list-objects-v2 --bucket ${BUCKET} --prefix ${PREFIX}/${EPOCH}/ --no-paginate --delimiter '/' --query 'reverse(CommonPrefixes[].[Prefix])' --output text | sort); do
-  err=0
-  aws s3 cp s3://${BUCKET}/${SEQ_PREFIX}snapshot_info.dat - | age -d -i ${IDENTITY_FILE} >/dev/null || err=1
-  if [ ${err} -ne 0 ]; then
+# Whether a chunk can be read right now: present, missing, archived or error.
+# head-object answers 200 for an object that is in Glacier and has not been
+# restored to S3 Standard, so the storage class has to be looked at to tell
+# "not there" from "not there yet".
+function chunk_state () {
+  local key=$1
+  local out status class restore
+
+  out=$(aws s3api head-object --bucket "${BUCKET}" --key "${key}" \
+          --query '[StorageClass,Restore]' --output text 2>&1)
+  status=$?
+
+  if [ ${status} -ne 0 ]; then
+    case ${out} in
+      *"(404)"*|*"Not Found"*)
+        printf 'missing\n'
+        ;;
+      *)
+        printf '%s\n' "${out}" >&2
+        printf 'error\n'
+        ;;
+    esac
+    return 0
+  fi
+
+  read -r class restore <<<"${out}"
+
+  case ${class} in
+    GLACIER|DEEP_ARCHIVE)
+      case ${restore} in
+        *'ongoing-request="false"'*) printf 'present\n' ;;
+        *)                           printf 'archived\n' ;;
+      esac
+      ;;
+    *)
+      printf 'present\n'
+      ;;
+  esac
+}
+
+# Writes the decrypted chunks of one sequence to stdout, in order.
+# 0: the whole sequence, 1: something failed, 4: still in Glacier.
+function fetch_chunks () {
+  local seq_prefix=$1
+  local key state
+  local -a status
+
+  for key in "${seq_prefix}"x{a..z}{a..z}{a..z}{a..z}; do
+    state=$(chunk_state "${key}")
+
+    case ${state} in
+      missing)
+        # The end of the sequence: the chunk names are generated, not listed.
+        return 0
+        ;;
+      archived)
+        echo "ERROR: ${key} is still in Glacier or Deep Archive." >&2
+        echo "       Restore the objects under ${seq_prefix} to S3 Standard" >&2
+        echo "       first (see examples/README.md), then run this again." >&2
+        return 4
+        ;;
+      error)
+        echo "ERROR: could not tell whether ${key} exists, stopping rather than" >&2
+        echo "       feeding btrfs receive a stream that stops halfway." >&2
+        return 1
+        ;;
+    esac
+
+    aws s3 cp "s3://${BUCKET}/${key}" - | age -d -i "${IDENTITY_FILE}"
+    status=("${PIPESTATUS[@]}")
+
+    if [ "${status[0]}" -ne 0 ] || [ "${status[1]}" -ne 0 ]; then
+      echo "ERROR: chunk ${key} could not be read" \
+           "(aws=${status[0]} age=${status[1]})" >&2
+      return 1
+    fi
+  done
+
+  echo "ERROR: ${seq_prefix} holds more chunks than the naming scheme allows" >&2
+  return 1
+}
+
+if ! SEQ_LIST=$(aws s3api list-objects-v2 --bucket "${BUCKET}" \
+      --prefix "${PREFIX}/${EPOCH}/" --delimiter '/' \
+      --query 'CommonPrefixes[].[Prefix]' --output text); then
+  echo "ERROR: could not list s3://${BUCKET}/${PREFIX}/${EPOCH}/" >&2
+  exit 1
+fi
+
+if [ -z "${SEQ_LIST}" ] || [ "${SEQ_LIST}" == "None" ]; then
+  echo "ERROR: no backup found in s3://${BUCKET}/${PREFIX}/${EPOCH}/" >&2
+  exit 1
+fi
+
+mapfile -t SEQ_PREFIXES < <(printf '%s\n' "${SEQ_LIST}" | LC_ALL=C sort)
+
+for SEQ_PREFIX in "${SEQ_PREFIXES[@]}"; do
+  # The sequence number without the salt, which is the name btrfs receive gives
+  # the restored snapshot
+  SEQ_NAME=$(printf '%s' "${SEQ_PREFIX}" | sed 's/.*\/\([^_\/]\+\)_[0-9a-f]*\/$/\1/')
+
+  if ! aws s3 cp "s3://${BUCKET}/${SEQ_PREFIX}snapshot_info.dat" - 2>/dev/null \
+       | age -d -i "${IDENTITY_FILE}" >/dev/null; then
     echo "    WARNING: ${SEQ_PREFIX} skipped.
     This is harmless if an incremental backup failed and the backup script handled it gracefully.
-    This can also be due to an unexpedcted file being present in the S3 bucket.
+    This can also be due to an unexpected file being present in the S3 bucket.
     However, if the next snapshot depends on this one, this is the end of it." >&2
-  else
-    for key in ${SEQ_PREFIX}x{a..z}{a..z}{a..z}{a..z}; do
-      if [[ ${key} =~ /x[a-z]*$ ]]; then
-        aws s3api head-object --bucket ${BUCKET} --key ${key}  >/dev/null 2>&1
-        if [[ $? -ne 0 ]]; then
-          break
-        fi
-        aws s3 cp s3://${BUCKET}/${key} - | age -d -i ${IDENTITY_FILE}
-        if [ "${PIPESTATUS}" != "0" ]; then
-          break
-        fi
-      fi
-    done | mbuffer -m 1G -q | lz4 -d | btrfs receive ${DEST}
-    if [ "${DELETE_PREVIOUS}" == true ] && [ ! -z "${PREV_SEQ}" ]; then
-      echo "Deleting previous snapshot ${DEST}/${PREV_SEQ}"
-      sudo btrfs subvolume delete ${DEST}/${PREV_SEQ}
-    fi
-    # Extract the previous' snapshot sequence number without the salt
-    PREV_SEQ=$(echo ${SEQ_PREFIX} | sed 's/.*\/\([^_\/]\+\)_[0-9a-f]*\/$/\1/')
+    continue
   fi
+
+  echo "Restoring ${SEQ_PREFIX}"
+  fetch_chunks "${SEQ_PREFIX}" | mbuffer -m 1G -q | lz4 -d | btrfs receive "${DEST}"
+  STATUS=("${PIPESTATUS[@]}")
+
+  if [ "${STATUS[0]}" -ne 0 ] || [ "${STATUS[1]}" -ne 0 ] \
+     || [ "${STATUS[2]}" -ne 0 ] || [ "${STATUS[3]}" -ne 0 ]; then
+    echo "ERROR: restoring ${SEQ_PREFIX} failed (chunks=${STATUS[0]}" \
+         "mbuffer=${STATUS[1]} lz4=${STATUS[2]} btrfs receive=${STATUS[3]})" >&2
+    echo "       You may have to delete a partly received ${DEST%/}/${SEQ_NAME}" >&2
+    echo "       before trying again." >&2
+    if [ "${STATUS[0]}" -eq 4 ]; then
+      EXIT_CODE=4
+    else
+      EXIT_CODE=2
+    fi
+    # Every later sequence is an increment on this one, so there is no point
+    # carrying on.
+    break
+  fi
+
+  # The next snapshot in the chain is on disk, so the one it was built from can
+  # go.
+  if [ "${DELETE_PREVIOUS}" == true ] && [ -n "${RESTORED_SEQ}" ]; then
+    echo "Deleting previous snapshot ${DEST%/}/${RESTORED_SEQ}"
+    btrfs subvolume delete "${DEST%/}/${RESTORED_SEQ}" \
+      || echo "WARNING: could not delete ${DEST%/}/${RESTORED_SEQ}" >&2
+  fi
+
+  RESTORED_SEQ=${SEQ_NAME}
 done
 
+if [ -z "${RESTORED_SEQ}" ] && [ "${EXIT_CODE}" -eq 0 ]; then
+  EXIT_CODE=2
+fi
+
 summarise
+exit "${EXIT_CODE}"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -44,9 +44,9 @@ setup () {
   echo "AGE-SECRET-KEY-EXAMPLE" >"${WORK}/identity.txt"
   # What cron sets, and therefore what the scripts have to cope with.
   export SHELL=/bin/sh
-  unset FAIL_STAGE FAIL_CHUNK FS_PREFIX AWS_LS_OK AWS_LIST_FAIL AWS_ARCHIVED \
-        AWS_HEAD_ERROR AGE_UNDECRYPTABLE NESTED_SUBVOLS STREAM_BYTES TEST_SALT \
-        TEST_NOW
+  unset FAIL_STAGE FAIL_CHUNK FAIL_RECEIVE FS_PREFIX AWS_LS_OK AWS_LIST_FAIL \
+        AWS_ARCHIVED AWS_HEAD_ERROR AWS_HANG AGE_UNDECRYPTABLE NESTED_SUBVOLS \
+        STREAM_BYTES TEST_SALT TEST_NOW
 }
 
 teardown () {
@@ -580,6 +580,87 @@ test_restore_deletes_previous_snapshots_with_d () {
   return 0
 }
 
+# ------------------------------------------------------- restore: failures
+#
+# Every sequence is an increment on the one before it, so a restore that fails
+# half way has to stop, say so, and leave the last good snapshot alone: that
+# snapshot is the parent the retry will need.
+
+restore_three_sequences () {
+  backup -c STANDARD -e first || return 1
+  TEST_NOW=2 backup -c STANDARD -e first || return 1
+  TEST_NOW=3 backup -c STANDARD -e first || return 1
+  mkdir -p "${WORK}/dest"
+  : >"${LOG}"
+}
+
+test_a_failed_receive_stops_the_restore () {
+  restore_three_sequences || { fail "the backups failed"; return 1; }
+
+  FAIL_RECEIVE=2 restore -e first -s "${WORK}/dest" -d
+  local status=$?
+  assert_status "${status}" 2 || return 1
+  assert_equal "$(grep -c '^RECEIVED: ' "${LOG}")" "1" || return 1
+  # The snapshot that did restore has to survive: it is what the next attempt
+  # will chain from.
+  assert_equal "$(ls "${WORK}/dest")" "1" || return 1
+  assert_contains "$(cat "${WORK}/stdout")" "restored in: ${WORK}/dest/1" || return 1
+  return 0
+}
+
+test_a_chunk_that_will_not_decrypt_stops_the_restore () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  TEST_NOW=2 backup -c STANDARD -e first || { fail "the second backup failed"; return 1; }
+  mkdir -p "${WORK}/dest"
+  : >"${LOG}"
+
+  AGE_UNDECRYPTABLE="subvol=2" restore -e first -s "${WORK}/dest"
+  local status=$?
+  assert_status "${status}" 2 || return 1
+  assert_equal "$(grep -c '^RECEIVED: ' "${LOG}")" "1" || return 1
+  return 0
+}
+
+# head-object answers 200 for an object still in Glacier, which is easily
+# mistaken for a chunk that is simply not there.
+test_an_archived_chunk_is_reported_as_such () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  mkdir -p "${WORK}/dest"
+  : >"${LOG}"
+
+  AWS_ARCHIVED=xaaaa restore -e first -s "${WORK}/dest"
+  local status=$?
+  assert_status "${status}" 4 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "Glacier" || return 1
+  return 0
+}
+
+test_a_failed_listing_is_an_error () {
+  mkdir -p "${WORK}/dest"
+  AWS_LIST_FAIL=1 restore -e first -s "${WORK}/dest"
+  assert_status "$?" 1 || return 1
+  return 0
+}
+
+test_an_empty_epoch_is_an_error () {
+  mkdir -p "${WORK}/dest"
+  restore -e nothing-here -s "${WORK}/dest"
+  assert_status "$?" 1 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "no backup found" || return 1
+  return 0
+}
+
+test_restoring_nothing_at_all_is_an_error () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  printf 'GARBAGE' >"${S3ROOT}/${BUCKET}/${PREFIX}/first/1_00000000deadbeef/snapshot_info.dat"
+  mkdir -p "${WORK}/dest"
+
+  AGE_UNDECRYPTABLE=GARBAGE restore -e first -s "${WORK}/dest"
+  assert_status "$?" 2 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "No snapshot was restored" || return 1
+  return 0
+}
+
 test_restore_without_arguments_prints_usage () {
   PATH="${TESTS_DIR}/stubs:${PATH}" "${REPO_DIR}/restore_backup.sh" \
     >"${WORK}/stdout" 2>"${WORK}/stderr"
@@ -633,6 +714,14 @@ run_test "restore replays every sequence in order"                 test_restore_
 run_test "restore skips a sequence with no valid marker"           test_restore_skips_a_sequence_with_no_valid_marker
 run_test "restore -d keeps only the last snapshot"                 test_restore_deletes_previous_snapshots_with_d
 run_test "restore without arguments prints the usage"              test_restore_without_arguments_prints_usage
+
+echo "Running the restore failure tests"
+run_test "a failed receive stops the restore"                      test_a_failed_receive_stops_the_restore
+run_test "a chunk that will not decrypt stops the restore"         test_a_chunk_that_will_not_decrypt_stops_the_restore
+run_test "an archived chunk is reported as such"                   test_an_archived_chunk_is_reported_as_such
+run_test "a failed listing is an error"                            test_a_failed_listing_is_an_error
+run_test "an empty epoch is an error"                              test_an_empty_epoch_is_an_error
+run_test "restoring nothing at all is an error"                    test_restoring_nothing_at_all_is_an_error
 
 echo
 echo "${PASSED} passed, ${FAILED} failed"

--- a/tests/stubs/btrfs
+++ b/tests/stubs/btrfs
@@ -67,10 +67,6 @@ case "$1 $2" in
     IFS= read -r stream
     header_read=$?
     cat >/dev/null
-    if [ "${FAIL_STAGE}" = receive ]; then
-      echo "ERROR: cannot find parent subvolume" >&2
-      exit 1
-    fi
     case ${header_read}${stream} in
       0BTRFS-STREAM*) ;;
       *) echo "ERROR: unexpected end of stream" >&2; exit 1 ;;
@@ -78,6 +74,10 @@ case "$1 $2" in
     name=${stream#BTRFS-STREAM subvol=}
     parent=${name#* parent=}
     name=${name%% *}
+    if [ "${FAIL_STAGE}" = receive ] || [ "${FAIL_RECEIVE}" = "${name}" ]; then
+      echo "ERROR: failed to receive ${name}" >&2
+      exit 1
+    fi
     # An incremental stream can only be received if its parent is already here.
     if [ "${parent}" != none ] && [ ! -d "${dest}/${parent}" ]; then
       echo "ERROR: cannot find parent subvolume ${parent}" >&2


### PR DESCRIPTION
**Severity: high — a restore that destroyed the chain looked like a successful one.**

Nothing about the restore was checked. The chunk loop was the left-hand side of a pipe, so its status was unobservable, and the receive pipeline's status was never read at all. When a sequence failed part way through the chain:

- the `ERR` trap printed "Last snapshot successfully restored";
- the `-d` branch went on to delete `${DEST}/${PREV_SEQ}` — the snapshot that had just been restored, which is exactly the parent a retry needs;
- the sequence number advanced anyway, so the final message named a snapshot that was never restored;
- and because `summarise` was the last command, the script exited **0**.

So a single mid-chain failure under `-d` — the option you reach for precisely because disk is short — destroyed the restored chain, told you it had worked, and left you to pay for the Glacier thaw again.

Making the chunk loop a function is what lets everything else be checked. It now looks at `age -d` as well as the download, instead of splicing the next chunk's plaintext in after one that failed. The rule is: **receive, verify, then delete the parent, then advance.** A sequence that fails stops the restore, because every later one is an increment on it, and the script exits non-zero. A sequence with no valid completion marker is still skipped rather than fatal — that is what a backup run that failed and cleaned up after itself leaves behind.

Two more in the same file:

- The sequence listing used `--no-paginate`, so an epoch with more than 1000 of them restored only the oldest 1000 and reported success. That is the same bug as #11, in the listing that fix left behind. A listing that failed outright gave an empty loop and exit 0.
- `head-object` answers 200 for an object still in Glacier, so a chunk that needs thawing was indistinguishable from one that is genuinely absent, and the stream simply stopped early. It is now told apart and reported as needing a thaw (exit 4).

Also drops the `sudo` in a script that already refuses to run as anyone but root, and a key-name test that was always true.

The restore had no documented exit codes at all, which left nothing for a scripted disaster-recovery check to look at; the README now has them.

**Verification:** six new tests — a receive that fails part way, a chunk that will not decrypt, a chunk still in Glacier, a listing that fails, an empty epoch, and every sequence being skipped. All six fail against the previous code. Suite: 41 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)