### PR TITLE
Refuse to run concurrently or with a clock that went backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ These scripts rely on well known command line tools and the AWS CLI:
 * age (or [rage](https://github.com/str4d/rage/) symlinked to `age` binary in PATH)
 * btrfs-tools
 * openssl
+* flock (from util-linux)
 
 # Design
 Rather than dealing with the complexity of custom file formats and metadata files, we use exclusively the state managed by btrfs-tools and file name conventions on S3.
 
 As such if you want to change the format (compression, encryption, file container, etc.), please start a new backup _epoch_ so as not to mix the two.
+
+Only one backup runs at a time per subvolume, whatever the epoch: a run takes an exclusive lock (in `/run/lock`, or `$TMPDIR` if that is not writable) and gives up with a return value of 1 if another already holds it. Two runs at once could otherwise pick the same parent snapshot and produce two branches of the same chain, which restores badly. Backups are also refused if the clock has gone backwards since the last snapshot, because restoring replays the sequences in numerical order.
 
 Snapshots live in `.stream_backup_<epoch>/` inside the subvolume, named after the second they were taken in. A new snapshot is created in `.stream_backup_<epoch>/.incomplete/` and only moved next to the others once every chunk *and* the completion marker have reached S3. That is what makes an interrupted backup safe: the next run can only ever chain from a snapshot whose upload finished, because a sequence with no completion marker is skipped when restoring, and anything chained from it could not be restored either. A snapshot found in `.incomplete/` at the start of a run is reported and deleted.
 

--- a/check_deps.sh
+++ b/check_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for cmd in age aws lz4 mbuffer split sed btrfs openssl; do
+for cmd in age aws lz4 mbuffer split sed btrfs openssl flock; do
   if ! command -v "${cmd}" &> /dev/null; then
     echo "command not found: ${cmd}" >&2
     exit 3

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -170,6 +170,26 @@ function latest_snapshot () {
   printf '%s\n' "${newest}"
 }
 
+# One run at a time per subvolume, and per subvolume rather than per epoch: with
+# -B a run in one epoch reads a snapshot belonging to another, and with -d a run
+# deletes one. The lock is held by the whole process tree, so a run whose upload
+# is stuck still counts as a run in progress.
+LOCK_DIR=/run/lock
+if [ ! -d "${LOCK_DIR}" ] || [ ! -w "${LOCK_DIR}" ]; then
+  LOCK_DIR=${TMPDIR:-/tmp}
+fi
+
+LOCK_NAME=${SUBV%/}
+LOCK_FILE=${LOCK_DIR}/stream_backup${LOCK_NAME//\//_}.lock
+
+exec 9>"${LOCK_FILE}" || exit 1
+
+if ! flock -n 9; then
+  echo "ERROR: another stream_backup.sh run is already working on ${SUBV}" >&2
+  echo "       (lock file ${LOCK_FILE}). Refusing to run two at once." >&2
+  exit 1
+fi
+
 aws s3 ls s3://${BUCKET}/${PREFIX} >/dev/null 2>&1 \
   && echo "SECURITY WARNING: current AWS IAM entity is allowed to list bucket contents! This can allow an attacker using the same identity to overwrite files and ruin your backups!" >&2
 
@@ -209,6 +229,17 @@ if [ -z "${LAST_SNAPSHOT}" ] && [ -n "${SOURCE_EPOCH}" ]; then
     exit 1
   fi
   SNAPSHOT_FROM_OTHER_EPOCH=true
+fi
+
+# Restoring replays sequences in the order of these numbers, so a snapshot that
+# sorts before the one it was made from could never be restored.
+if [ -n "${LAST_SNAPSHOT}" ] && [ "${SEQ}" -le "${LAST_SNAPSHOT}" ]; then
+  echo "ERROR: this run's sequence number (${SEQ}) is not newer than the last" >&2
+  echo "       snapshot's (${LAST_SNAPSHOT}). The clock has gone backwards, or" >&2
+  echo "       a backup has already been taken this second. Restoring replays" >&2
+  echo "       sequences in numerical order, so this backup could not be" >&2
+  echo "       restored after its own parent. Fix the clock and run again." >&2
+  exit 1
 fi
 
 SEND_ARGS=()

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,6 +32,8 @@ CURRENT=""
 # ---------------------------------------------------------------- test harness
 
 setup () {
+  # The previous test's TMPDIR has been deleted by now.
+  unset TMPDIR
   WORK=$(mktemp -d)
   export TEST_SUBV=${WORK}/subv
   export S3ROOT=${WORK}/s3
@@ -44,6 +46,8 @@ setup () {
   echo "AGE-SECRET-KEY-EXAMPLE" >"${WORK}/identity.txt"
   # What cron sets, and therefore what the scripts have to cope with.
   export SHELL=/bin/sh
+  # Keeps temporary files, including lock files, inside the test's own directory.
+  export TMPDIR=${WORK}
   unset FAIL_STAGE FAIL_CHUNK FAIL_RECEIVE FS_PREFIX AWS_LS_OK AWS_LIST_FAIL \
         AWS_ARCHIVED AWS_HEAD_ERROR AWS_HANG AGE_UNDECRYPTABLE NESTED_SUBVOLS \
         STREAM_BYTES TEST_SALT TEST_NOW
@@ -535,6 +539,69 @@ test_a_failed_tidy_up_keeps_the_backup () {
   return 0
 }
 
+# ------------------------------------------------------- backup: runs that overlap
+
+# Two runs at once can both pick the same parent, or one can pick a snapshot the
+# other has not finished uploading.
+test_a_second_run_on_the_same_subvolume_is_refused () {
+  local i=0
+
+  (
+    AWS_HANG=1 PGID_FILE="${WORK}/pgid" PATH="${TESTS_DIR}/stubs:${PATH}" \
+      setsid --fork --wait "${REPO_DIR}/stream_backup.sh" \
+        -r "${WORK}/recipients.txt" -b "${BUCKET}" -p "${PREFIX}" \
+        -s "${TEST_SUBV}" -c STANDARD -e first >/dev/null 2>&1
+    echo $? >"${WORK}/status"
+  ) &
+
+  while [ ! -s "${WORK}/pgid" ]; do
+    i=$((i + 1))
+    [ "${i}" -gt 200 ] && { fail "the first run never got as far as uploading"; return 1; }
+    sleep 0.05
+  done
+
+  # A different epoch, because the lock is about the subvolume, not the epoch.
+  TEST_NOW=2 backup -c STANDARD -e second
+  local status=$?
+
+  kill -TERM -"$(cat "${WORK}/pgid")" 2>/dev/null
+  i=0
+  while [ ! -f "${WORK}/status" ]; do
+    i=$((i + 1))
+    [ "${i}" -gt 200 ] && break
+    sleep 0.05
+  done
+
+  assert_status "${status}" 1 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "Refusing to run two at once" || return 1
+  return 0
+}
+
+# Restoring replays sequences in the order of their numbers, so a snapshot
+# numbered below its own parent could never be restored.
+test_a_clock_that_went_backwards_is_refused () {
+  TEST_NOW=100 backup -c STANDARD -e first \
+    || { fail "the first backup failed"; return 1; }
+  : >"${LOG}"
+
+  TEST_NOW=50 backup -c STANDARD -e first
+  local status=$?
+  assert_status "${status}" 1 || return 1
+  assert_equal "$(uploaded)" "" || return 1
+  assert_equal "$(snapshots)" ".stream_backup_first/100" || return 1
+  return 0
+}
+
+test_a_second_backup_in_the_same_second_is_refused () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  : >"${LOG}"
+
+  backup -c STANDARD -e first
+  assert_status "$?" 1 || return 1
+  assert_equal "$(uploaded)" "" || return 1
+  return 0
+}
+
 # ------------------------------------------------------------------------ restore
 
 test_restore_replays_every_sequence_in_order () {
@@ -708,6 +775,11 @@ echo "Running the interrupted backup tests"
 run_test "an orphaned snapshot is not used as a parent"            test_an_orphaned_snapshot_is_not_used_as_a_parent
 run_test "a terminated backup leaves nothing behind"               test_a_terminated_backup_leaves_nothing_behind
 run_test "a failed tidy up keeps the backup"                       test_a_failed_tidy_up_keeps_the_backup
+
+echo "Running the overlapping run tests"
+run_test "a second run on the same subvolume is refused"           test_a_second_run_on_the_same_subvolume_is_refused
+run_test "a clock that went backwards is refused"                  test_a_clock_that_went_backwards_is_refused
+run_test "a second backup in the same second is refused"           test_a_second_backup_in_the_same_second_is_refused
 
 echo "Running the restore tests"
 run_test "restore replays every sequence in order"                 test_restore_replays_every_sequence_in_order


### PR DESCRIPTION
**Severity: medium.**

Nothing stopped two runs overlapping. Both could choose the same parent and produce two branches of one chain — which restores badly under `-d`, since the shared parent is deleted after the first branch — or the second could choose a snapshot the first had not finished uploading. The shipped crontab's own comments admit it assumes no run takes more than 24h.

A run now takes an exclusive lock with `flock`, which cannot go stale if the run is killed, and gives up immediately rather than queueing. The lock is per subvolume rather than per epoch: with `-B` a run reads a snapshot belonging to another epoch, and with `-d` it deletes one, so a per-epoch lock would not protect the case that matters. It is taken before the leftover-snapshot recovery added in the previous PR, so recovery cannot delete a concurrent run's staged snapshot. The lock is held by the whole process tree, so a run whose upload is stuck still counts as in progress — which is the behaviour you want.

Sequence numbers come from the clock and restoring replays them in numerical order, so a snapshot numbered below its own parent could never be restored: a machine with no RTC booting before NTP, a VM resumed from a snapshot, a dying CMOS battery. That is now refused before the snapshot is taken, which also catches a second backup within the same second.

`flock` becomes a declared dependency. It is part of util-linux and present on every Linux that can run btrfs, and `check_deps.sh` now fails loudly rather than silently if it is ever missing. If you would rather not take the dependency, the alternative is a `mkdir` lock plus a `kill -0` liveness check — say so and I will swap it in.

**Verification:** three new tests — a second run refused while the first is uploading (in a different epoch, to prove the lock is about the subvolume), a clock that goes backwards, and a second backup in the same second. All three fail against the previous code. Suite: 44 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)