### PR TITLE
Warn about nested subvolumes and tidy up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,3 +14,15 @@ jobs:
       # itself in a user namespace; here it is simpler to just be root.
       - name: Run the test suite
         run: sudo ./tests/run.sh
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Lint the scripts
+        run: |
+          shellcheck --severity=warning \
+            stream_backup.sh restore_backup.sh check_deps.sh \
+            tests/run.sh tests/stubs/*

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It is important that you check the return value of these scripts for proper moni
 ## stream_backup.sh
 
 * 0: everything went fine
-* 1: a "usage" error occured. You used a unrecognised command switch, or referenced a volume or snapshot that does not exist
+* 1: a "usage" error occurred. You used an unrecognised command switch, or referenced a volume or snapshot that does not exist
 * 2: an error occurred after the snapshot was created, **you should pay close attention to these**! The script will have tried to delete the newly created snapshot so that subsequent incremental backups can be made from the last good known state
 * 3: a required dependency is not installed
 * 4: the backup itself completed and is safe in S3, but tidying up afterwards did not. Nothing is at risk and there is nothing to re-run, but snapshots will accumulate on disk until you look into it
@@ -50,11 +50,14 @@ A restore stops at the first sequence it cannot replay, because every later one 
 This is all rather common sense, but:
 
 ## AWS Credentials
-Whether you use locally stored credentials, an EC2 instance role, or IAM Roles Anywhere, an attacker who gains access to your machine will get access to your IAM entity. It is therefore important to reduce the permissions of the polices attacheds to the entity as much as possible. In particular *do not* grant any s3:List* or s3:Delete* permissions to the backup process.
+Whether you use locally stored credentials, an EC2 instance role, or IAM Roles Anywhere, an attacker who gains access to your machine will get access to your IAM entity. It is therefore important to reduce the permissions of the policies attached to the entity as much as possible. In particular *do not* grant any s3:List* or s3:Delete* permissions to the backup process.
 
-Indeed there is no way of preventing _overwriting_ a file on S3, therefore if you know the file name (either because it's guessable or because you can list the bucket), the s3:PutObject permission (that we can't do without) gives you permission to overwrite and delete/alter the data.
+The backup cannot do without s3:PutObject, and that permission alone is enough to write over an object whose name you know. So if the names are guessable, or the bucket can be listed, whoever reaches the machine can destroy the backups by overwriting them. We make the object names unguessable by putting a random string in every key.
 
-We make sure that the object names in AWS are not guessable using random strings in the key names.
+Unguessable names are worth having, but treat them as defence in depth rather than as the control: the name of the object being written is visible in the process list for as long as the upload runs. The control is on the bucket, and costs these scripts nothing:
+
+* **Enable versioning**, and grant s3:DeleteObjectVersion to nobody. An overwrite then only adds a version, and the original object is still there.
+* For a stronger guarantee, **S3 Object Lock** in compliance mode makes objects genuinely immutable until they expire — including to you, so read up on it before turning it on.
 
 You'll need to create a different role for restoring a backup, that has no s3:PutObject permission, but s3:GetObject and s3:ListBucket.
 
@@ -73,7 +76,7 @@ If you lose the private key, your backup will be rendered completely useless.
 A chain is only as strong as its weakest link. If there is any corruption in an incremental backup, you will not be able to restore your file beyond that point! _See epochs below_ as a tool to handle this
 
 ## Deleting old backups
-It's a complex and dangerous topic on which we provide no guidance, we merely suggest that it should be automated process (to preven human error), not running on the same machine (for security reasons), and that is has human oversight.
+It's a complex and dangerous topic on which we provide no guidance, we merely suggest that it should be an automated process (to prevent human error), not running on the same machine (for security reasons), and that it has human oversight.
 
 # Making a backup
 
@@ -87,7 +90,7 @@ When you start a new epoch, the backup script will *not* delete the last snapsho
 
 You can use it to achieve different goals by using multiple epochs in parallel or in sequence, for example:
 * You do a backup daily and a new full backup every 6 months, so you start a new epoch every 6 months
-* You have a monthly incremental backup on Glacier Deep Archive, with an new full backup (and a new epoch) every year, and a daily backup on S3 Standard with a new epoch every month. In that case you would, for example, have always two active epochs, with names like monthly-glacier-_year_ and daily-standard-_month_
+* You have a monthly incremental backup on Glacier Deep Archive, with a new full backup (and a new epoch) every year, and a daily backup on S3 Standard with a new epoch every month. In that case you would, for example, have always two active epochs, with names like monthly-glacier-_year_ and daily-standard-_month_
 * You can branch your epochs, consider for example this crontab (boring mandatory parameters replaced with \[...\] for clarity):
 
 ```
@@ -96,7 +99,7 @@ You can use it to achieve different goals by using multiple epochs in parallel o
 0 3 2-31   *   * stream_backup [...] -c STANDARD_IA  -e daily-$(date +%Y-%m) -B monthly-$(date +%Y)
 ```
 
-This way you have daily backups, but a maximum chain lenth of 12+30=42 incremental backups instead of 365. We also mix and match storage classes, so that when we start the new year and delete the old epochs, we don't waste too much money on the 180 days of minimum storage duration for Glacier Deep Archive.
+This way you have daily backups, but a maximum chain length of 12+30=42 incremental backups instead of 365. We also mix and match storage classes, so that when we start the new year and delete the old epochs, we don't waste too much money on the 180 days of minimum storage duration for Glacier Deep Archive.
 
 # Restoring a backup
 
@@ -109,10 +112,10 @@ We recommend using an S3 batch operation for this, again you can look it up, but
 Beware of the minimum storage duration and [pro-rated charge equal to the storage charge for the remaining days](https://aws.amazon.com/s3/pricing/)!
 
 ## Disk space consideration
-Standard behaviour when restoring a backup is that all the data from every snapshot will be restored, including files that have been deleted in later snapshots. This may very well exceed the space that is available on your machine. You can use the `-d` option to mitigate this, if you don't need do go back to a particular point in time.
+Standard behaviour when restoring a backup is that all the data from every snapshot will be restored, including files that have been deleted in later snapshots. This may very well exceed the space that is available on your machine. You can use the `-d` option to mitigate this, if you don't need to go back to a particular point in time.
 
 ## Bandwidth consideration
-If your target machine is outside of AWS, you will incur Data Transfer Out (DTO) charges, and just like mentioned above, you will download and restore every bid of data ever saved on this subvolume, including files that have been deleted later in the sequence.
+If your target machine is outside of AWS, you will incur Data Transfer Out (DTO) charges, and just like mentioned above, you will download and restore every bit of data ever saved on this subvolume, including files that have been deleted later in the sequence.
 
 It _may_ make financial sense (and even reduce the restoration times), to use an EC2 instance with sufficient local storage (*not* EBS) in the same region as your S3 backup.
 
@@ -124,4 +127,4 @@ As usual, calculations to see if this makes sense are left to the reader.
 
 ## Branched backups
 To restore a branch backup, you just restore the branches in order of precedence. For example, on the 18th of March 2024, to restore the latest backup made with the crontab above, one would, after the restoration from Glacier to S3 is completed, first restore epoch monthly-2024 and then daily-2024-03.
-This will bring back the full backup of the 1st of January 2024, then the two monthy increments in February and March, and finally every daily increment since the 2nd of March.
+This will bring back the full backup of the 1st of January 2024, then the two monthly increments in February and March, and finally every daily increment since the 2nd of March.

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ Create an S3 bucket, choose a prefix you want to write the backups to.
 
 Every month on the 10th, at 0507UTC, it creates new lifecycle rules for the s3 bucket and prefix:
 * On the 4th of each month, it deletes the incremental daily backups of the previous month.
-* On the 4th of february every year, it deletes the incremental montly backups of the previous year.
+* On the 4th of february every year, it deletes the incremental monthly backups of the previous year.
 
 # Restoring
 
@@ -41,14 +41,14 @@ export STORAGE_CLASS="DEEP_ARCHIVE"
 aws s3api list-objects-v2 --bucket $BUCKET --prefix $PREFIX --output json | jq --arg bucket ${BUCKET} -r '.Contents[] | select(.StorageClass == "DEEP_ARCHIVE") | "\"\($bucket)\",\"\(.Key)\""' > job.csv
 ```
 
-This should produce a `job.csv` file that you need to put on the S3 bucket at `s3://$BUCKET/$PREFIX/restore/job.csv`. Make a note of the object's  ETAG (MD5 sum). In theory you can use any bucket and prefix, but the preivous path aligns with the permissions given by the `./aws/expire-old-backups.cfn.yaml` CloudFormation template.
+This should produce a `job.csv` file that you need to put on the S3 bucket at `s3://$BUCKET/$PREFIX/restore/job.csv`. Make a note of the object's ETag (MD5 sum). In theory you can use any bucket and prefix, but the previous path aligns with the permissions given by the `./aws/expire-old-backups.cfn.yaml` CloudFormation template.
 
 ## Create a restore job
 
 In the following example, replace:
 * `REGION`, self explanatory
 * `ACCOUNT_ID`, self explanatory
-* `JOB_TIER`, can be `EXPEDITED`, `STANDARD` or `BULK` (See [documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html) and [princing](https://aws.amazon.com/s3/pricing/))
+* `JOB_TIER`, can be `EXPEDITED`, `STANDARD` or `BULK` (See [documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html) and [pricing](https://aws.amazon.com/s3/pricing/))
 * `BUCKET`, self explanatory, *multiple occurences*
 * `PREFIX`, self explanatory, *multiple occurences*
 * `BulkRetrievalRole_ARN`, is an IAM role created by the `./aws/expire-old-backups.cfn.yaml` CloudFormation template

--- a/examples/aws/expire-old-backups.cfn.yaml
+++ b/examples/aws/expire-old-backups.cfn.yaml
@@ -167,7 +167,7 @@ Resources:
   EventBridgeRule:
     Type: AWS::Events::Rule
     Properties:
-      Name: triggerBtrfsSendToS3LCPolictCreation
+      Name: triggerBtrfsSendToS3LCPolicyCreation
       Description: 'Trigger Lambda function to update S3 lifecycle policies'
       ScheduleExpression: 'cron(7 5 10 * ? *)'
       State: ENABLED

--- a/examples/crontabs/daily-and-monthly.txt
+++ b/examples/crontabs/daily-and-monthly.txt
@@ -1,12 +1,12 @@
 # Crontab to take daily and monthly snapshot taking advantage of the branched
-# feature so that the maximum chain lenth is 12+30=42 on December 31st.
+# feature so that the maximum chain length is 12+30=42 on December 31st.
 # It tries to optimize the cost of storage assuming you delete old epochs on
 # the 4th of each month, taking into account early deletion fees.
 # It also assumes that none of these operations take more than 24h and that
 # 2100GMT is the beginning of your "quiet" hours.
 
 #
-# You if you rely on emails to monitor failures, you could wrap all these
+# If you rely on emails to monitor failures, you could wrap all these
 # commands with https://habilis.net/cronic/ to avoid sending emails on success
 #
 
@@ -25,7 +25,7 @@ SUBVOLUME=/path/to/mounted/btrfs/subvolume
 # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # |  |  |  |  |
 
-# Do a montly scrub, towards the end of the month
+# Do a monthly scrub, towards the end of the month
 0 21 27    *   *  btrfs scrub start -B ${SUBVOLUME}
 
 # Every month, perform an incremental backup relative to the previous month.
@@ -34,7 +34,7 @@ SUBVOLUME=/path/to/mounted/btrfs/subvolume
 # On January 1st, get rid of last year's snapshot
 1 0   1    1   * btrfs subvolume delete ${SUBVOLUME}/.stream_backup_monthly-$(date -d '-1 day' +\%Y)/* && rmdir ${SUBVOLUME}/.stream_backup_monthly-$(date -d '-1 day' +\%Y)
 
-# Every day (except the first day of the month, as we take a montly snapshot on
+# Every day (except the first day of the month, as we take a monthly snapshot on
 # that day), perform an incremental backup relative to the previous day. On the
 # second day of the month, it will start a new epoch automatically, branched from
 # the current monthly backup taken the day before

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -14,13 +14,13 @@ if [ "$EUID" -ne 0 ]
   exit 1
 fi
 
-$(dirname "$0")/check_deps.sh || exit 3
+"$(dirname "$0")/check_deps.sh" || exit 3
 
 DELETE_PREVIOUS=false
 
-OPTSTRING="b:p:e:i:s:d"
+OPTSTRING=":b:p:e:i:s:d"
 
-while getopts ${OPTSTRING} opt; do
+while getopts "${OPTSTRING}" opt; do
   case ${opt} in
     b)
       echo "Bucket: ${OPTARG}"
@@ -46,12 +46,23 @@ while getopts ${OPTSTRING} opt; do
       echo "Delete all restored snapshots but the last one"
       DELETE_PREVIOUS=true
       ;;
+    :)
+      echo "Option -${OPTARG} needs an argument." >&2
+      exit 1
+      ;;
     ?)
-      echo "Invalid option: -${OPTARG}."
+      echo "Invalid option: -${OPTARG}." >&2
       exit 1
       ;;
   esac
 done
+
+shift $((OPTIND - 1))
+
+if [ $# -ne 0 ]; then
+  echo "Unexpected argument: $1" >&2
+  exit 1
+fi
 
 if [ "" == "$IDENTITY_FILE" ] || [ "" == "$BUCKET" ] || [ "" == "$PREFIX" ] || [ "" == "$EPOCH" ] || [ "" == "$DEST" ]; then
 cat << EOF

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -17,8 +17,9 @@ fi
 "$(dirname "$0")/check_deps.sh" || exit 3
 
 DELETE_PREVIOUS=false
+MBUFFER_SIZE="1G"
 
-OPTSTRING=":b:p:e:i:s:d"
+OPTSTRING=":b:p:e:i:s:m:d"
 
 while getopts "${OPTSTRING}" opt; do
   case ${opt} in
@@ -41,6 +42,10 @@ while getopts "${OPTSTRING}" opt; do
     s)
       echo "Restore path: ${OPTARG}"
       DEST=${OPTARG}
+      ;;
+    m)
+      echo "Buffer size: ${OPTARG}"
+      MBUFFER_SIZE=${OPTARG}
       ;;
     d) 
       echo "Delete all restored snapshots but the last one"
@@ -73,6 +78,9 @@ Usage:
   -p prefix   : a prefix to use in that bucket
   -e epoch    : epoch of the backup we want to restore
   -s path     : BTRFS path were to restore the backup
+  [-m size]   : how much of the stream to hold in memory while
+                restoring. Default to 1G, K,M,G suffixes are
+                supported
   [-d]        : after restoring each incremental backup, delete
                 the one it's based on to save space, thus
                 keeping only the last version
@@ -212,7 +220,7 @@ for SEQ_PREFIX in "${SEQ_PREFIXES[@]}"; do
   fi
 
   echo "Restoring ${SEQ_PREFIX}"
-  fetch_chunks "${SEQ_PREFIX}" | mbuffer -m 1G -q | lz4 -d | btrfs receive "${DEST}"
+  fetch_chunks "${SEQ_PREFIX}" | mbuffer -m "${MBUFFER_SIZE}" -q | lz4 -d | btrfs receive "${DEST}"
   STATUS=("${PIPESTATUS[@]}")
 
   if [ "${STATUS[0]}" -ne 0 ] || [ "${STATUS[1]}" -ne 0 ] \

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -121,7 +121,7 @@ function chunk_state () {
           --query '[StorageClass,Restore]' --output text 2>&1)
   status=$?
 
-  if [ ${status} -ne 0 ]; then
+  if [ "${status}" -ne 0 ]; then
     case ${out} in
       *"(404)"*|*"Not Found"*)
         printf 'missing\n'

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -14,7 +14,7 @@ if [ "$EUID" -ne 0 ]
   exit 1
 fi
 
-$(dirname "$0")/check_deps.sh || exit 3
+"$(dirname "$0")/check_deps.sh" || exit 3
 
 # GNU split runs its --filter through $SHELL, which is the login shell of
 # whoever started us and need not even be bash. Pin it to the interpreter
@@ -37,9 +37,9 @@ CHUNK_SIZE="512M"
 SOURCE_EPOCH=""
 SNAPSHOT_FROM_OTHER_EPOCH=false
 
-OPTSTRING="r:b:p:e:c:s:B:S:d"
+OPTSTRING=":r:b:p:e:c:s:B:S:d"
 
-while getopts ${OPTSTRING} opt; do
+while getopts "${OPTSTRING}" opt; do
   case ${opt} in
     r)
       echo "Recipients file path: ${OPTARG}"
@@ -77,12 +77,23 @@ while getopts ${OPTSTRING} opt; do
       echo "Will delete previous snapshot in the same epoch"
       DELETE_PREVIOUS=true
       ;;
+    :)
+      echo "Option -${OPTARG} needs an argument." >&2
+      exit 1
+      ;;
     ?)
-      echo "Invalid option: -${OPTARG}."
+      echo "Invalid option: -${OPTARG}." >&2
       exit 1
       ;;
   esac
 done
+
+shift $((OPTIND - 1))
+
+if [ $# -ne 0 ]; then
+  echo "Unexpected argument: $1" >&2
+  exit 1
+fi
 
 if [ "" == "$RECIPIENTS_FILE" ] || [ "" == "$BUCKET" ] || [ "" == "$PREFIX" ] || [ "" == "$EPOCH" ] || [ "" == "$SCLASS" ] || [ "" == "$SUBV" ]; then
 cat << EOF

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -166,6 +166,25 @@ function on_signal () {
   exit 2
 }
 
+# A size in split's notation as a plain number of bytes, or nothing if it is
+# written in a way we do not recognise.
+function size_to_bytes () {
+  local size=$1
+  local number=${size%[KkMmGgTt]}
+
+  case ${number} in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+
+  case ${size} in
+    *[0-9]) printf '%s\n' "${number}" ;;
+    *[Kk])  printf '%s\n' "$(( number * 1024 ))" ;;
+    *[Mm])  printf '%s\n' "$(( number * 1024 ** 2 ))" ;;
+    *[Gg])  printf '%s\n' "$(( number * 1024 ** 3 ))" ;;
+    *[Tt])  printf '%s\n' "$(( number * 1024 ** 4 ))" ;;
+  esac
+}
+
 # Name of the newest snapshot in a snapshot directory, or nothing if it holds
 # none. Our snapshots are named after the second they were taken in, so anything
 # that is not a plain number was not put there by this script.
@@ -309,7 +328,11 @@ btrfs subvolume snapshot -r "${SUBV}" "${SNAPSHOT_STAGED}" || exit 1
 SEND_LOG=$(mktemp) || exit 2
 
 S3_SEQ_URL="s3://${BUCKET}/${PREFIX}/${EPOCH}/${SEQ_SALTED}"
-export RECIPIENTS_FILE S3_SEQ_URL SCLASS
+# Uploading from a stream, the AWS CLI has no idea how much is coming, so it
+# uses 8MiB parts and runs into the 10000 part limit a little under 78GiB.
+# Telling it how big a chunk is lets it size the parts accordingly.
+EXPECTED_SIZE=$(size_to_bytes "${CHUNK_SIZE}")
+export RECIPIENTS_FILE S3_SEQ_URL SCLASS EXPECTED_SIZE
 
 # stdout is the backup itself, and btrfs send writes progress as well as errors
 # to stderr, so its stderr goes to a file and is shown only on failure.
@@ -317,7 +340,10 @@ if ! btrfs send "${SEND_ARGS[@]}" 2>"${SEND_LOG}" \
 	| lz4 \
 	| mbuffer -m "${MBUFFER_SIZE}" -q \
 	| SHELL="${SPLIT_SHELL}" split -b ${CHUNK_SIZE} --suffix-length 4 --filter \
-	'set -o pipefail; age -R "${RECIPIENTS_FILE}" | aws s3 cp - "${S3_SEQ_URL}/${FILE}" --storage-class "${SCLASS}"'
+	'set -o pipefail
+	 age -R "${RECIPIENTS_FILE}" \
+	   | aws s3 cp - "${S3_SEQ_URL}/${FILE}" --storage-class "${SCLASS}" \
+	       ${EXPECTED_SIZE:+--expected-size "${EXPECTED_SIZE}"}'
 then
   STATUS=("${PIPESTATUS[@]}")
   echo "ERROR: the backup stream failed (btrfs send=${STATUS[0]} lz4=${STATUS[1]}" \

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -210,6 +210,19 @@ if ! btrfs subvolume show "${SUBV}" >/dev/null 2>&1; then
   exit 1
 fi
 
+# Snapshots are not recursive, and neither is the stream: a subvolume nested
+# inside this one arrives as an empty directory. Docker's btrfs driver, snapper
+# and LXD all create them under paths people back up.
+NESTED=$(btrfs subvolume list -o "${SUBV}" 2>/dev/null \
+           | grep -v '/\.stream_backup_' || true)
+
+if [ -n "${NESTED}" ]; then
+  echo "WARNING: ${SUBV} contains nested subvolumes. They will be backed up as" >&2
+  echo "         EMPTY directories, because snapshots do not descend into them." >&2
+  echo "         Back them up separately if you need their contents:" >&2
+  printf '%s\n' "${NESTED}" >&2
+fi
+
 EPOCH_DIR=${SUBV%/}/.stream_backup_${EPOCH}
 # A snapshot is only moved out of here once its upload has completed, so
 # whatever is left in it is unusable, and being in it is what stops

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -34,10 +34,11 @@ BACKUP_OK=false
 HOUSEKEEPING_FAILED=false
 DELETE_PREVIOUS=false
 CHUNK_SIZE="512M"
+MBUFFER_SIZE="512M"
 SOURCE_EPOCH=""
 SNAPSHOT_FROM_OTHER_EPOCH=false
 
-OPTSTRING=":r:b:p:e:c:s:B:S:d"
+OPTSTRING=":r:b:p:e:c:s:B:S:m:d"
 
 while getopts "${OPTSTRING}" opt; do
   case ${opt} in
@@ -72,6 +73,10 @@ while getopts "${OPTSTRING}" opt; do
     S)
       echo "Chunks size: ${OPTARG}"
       CHUNK_SIZE=${OPTARG}
+      ;;
+    m)
+      echo "Buffer size: ${OPTARG}"
+      MBUFFER_SIZE=${OPTARG}
       ;;
     d) 
       echo "Will delete previous snapshot in the same epoch"
@@ -116,6 +121,9 @@ Usage:
                 backups into epochs of different periodicity
   [-S size]   : size of chunks to send to S3. Default to 512M
                 K,M,G suffixes are supported
+  [-m size]   : how much of the stream to hold in memory while
+                uploading. Default to 512M, K,M,G suffixes are
+                supported
   [-d]        : when the upload succeedes, delete the older snapshot
                 defaults to keep the old snapshot. Does not delete
                 the previous snapshot if it is in a different epoch
@@ -307,7 +315,7 @@ export RECIPIENTS_FILE S3_SEQ_URL SCLASS
 # to stderr, so its stderr goes to a file and is shown only on failure.
 if ! btrfs send "${SEND_ARGS[@]}" 2>"${SEND_LOG}" \
 	| lz4 \
-	| mbuffer -m ${CHUNK_SIZE} -q \
+	| mbuffer -m "${MBUFFER_SIZE}" -q \
 	| SHELL="${SPLIT_SHELL}" split -b ${CHUNK_SIZE} --suffix-length 4 --filter \
 	'set -o pipefail; age -R "${RECIPIENTS_FILE}" | aws s3 cp - "${S3_SEQ_URL}/${FILE}" --storage-class "${SCLASS}"'
 then

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -114,7 +114,7 @@ Usage:
                 incremental
   -c class    : S3 storage class, see "aws s3 cp help" for
                 supported classes
-  -s path     : path of the subvolume to make a shapshot and backup
+  -s path     : path of the subvolume to make a snapshot and backup
                 of
   [-B epoch]  : use as a starting point when starting a new epoch.
                 This is useful to break long chains of incremental
@@ -124,7 +124,7 @@ Usage:
   [-m size]   : how much of the stream to hold in memory while
                 uploading. Default to 512M, K,M,G suffixes are
                 supported
-  [-d]        : when the upload succeedes, delete the older snapshot
+  [-d]        : when the upload succeeds, delete the older snapshot
                 defaults to keep the old snapshot. Does not delete
                 the previous snapshot if it is in a different epoch
 EOF
@@ -228,7 +228,7 @@ if ! flock -n 9; then
   exit 1
 fi
 
-aws s3 ls s3://${BUCKET}/${PREFIX} >/dev/null 2>&1 \
+aws s3 ls "s3://${BUCKET}/${PREFIX}" >/dev/null 2>&1 \
   && echo "SECURITY WARNING: current AWS IAM entity is allowed to list bucket contents! This can allow an attacker using the same identity to overwrite files and ruin your backups!" >&2
 
 SEQ=$(date +%s)
@@ -339,7 +339,7 @@ export RECIPIENTS_FILE S3_SEQ_URL SCLASS EXPECTED_SIZE
 if ! btrfs send "${SEND_ARGS[@]}" 2>"${SEND_LOG}" \
 	| lz4 \
 	| mbuffer -m "${MBUFFER_SIZE}" -q \
-	| SHELL="${SPLIT_SHELL}" split -b ${CHUNK_SIZE} --suffix-length 4 --filter \
+	| SHELL="${SPLIT_SHELL}" split -b "${CHUNK_SIZE}" --suffix-length 4 --filter \
 	'set -o pipefail
 	 age -R "${RECIPIENTS_FILE}" \
 	   | aws s3 cp - "${S3_SEQ_URL}/${FILE}" --storage-class "${SCLASS}" \
@@ -386,7 +386,7 @@ rmdir -- "${STAGE_DIR}" 2>/dev/null
 # The backup is already safe in S3 by now, so failing here is not fatal.
 if     [ "${DELETE_PREVIOUS}" == true ] \
     && [ -n "${LAST_SNAPSHOT}" ] \
-    && [ ${SNAPSHOT_FROM_OTHER_EPOCH} == false ]; then
+    && [ "${SNAPSHOT_FROM_OTHER_EPOCH}" == false ]; then
   if ! btrfs subvolume delete "${PARENT_PATH}"; then
     echo "WARNING: the backup completed, but the snapshot it was made from" >&2
     echo "         (${PARENT_PATH}) could not be deleted. Snapshots will pile" >&2

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -356,7 +356,7 @@ rm -f -- "${SEND_LOG}"
 SEND_LOG=""
 
 # We only write the subvolume information to S3 at the end, as a marker of completion of the backup
-# having the subvolume information might help debuging tricky situations.
+# having the subvolume information might help debugging tricky situations.
 SNAPSHOT_INFO=$(btrfs subvolume show "${SNAPSHOT_STAGED}")
 
 if [ -z "${SNAPSHOT_INFO}" ]; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -366,6 +366,42 @@ test_unknown_subvolume_is_an_error () {
   return 0
 }
 
+# Uploading from a stream, the CLI otherwise assumes 8MiB parts and gives up at
+# the 10000 part limit, a little under 78GiB.
+test_the_upload_is_told_how_big_a_chunk_is () {
+  backup -c STANDARD -e first -S 1G
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(actions)" "EXPECTED_SIZE: 1073741824" || return 1
+  return 0
+}
+
+test_nested_subvolumes_are_reported () {
+  NESTED_SUBVOLS="ID 256 gen 9 top level 5 path subv/var/lib/docker
+" backup -c STANDARD -e first
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "nested subvolumes" || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "var/lib/docker" || return 1
+  return 0
+}
+
+test_an_unknown_option_is_reported_with_its_name () {
+  PATH="${TESTS_DIR}/stubs:${PATH}" "${REPO_DIR}/stream_backup.sh" -Z \
+    >"${WORK}/stdout" 2>"${WORK}/stderr"
+  assert_status "$?" 1 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "Invalid option: -Z" || return 1
+  return 0
+}
+
+test_an_option_without_its_argument_is_reported () {
+  PATH="${TESTS_DIR}/stubs:${PATH}" "${REPO_DIR}/stream_backup.sh" -b \
+    >"${WORK}/stdout" 2>"${WORK}/stderr"
+  assert_status "$?" 1 || return 1
+  assert_contains "$(cat "${WORK}/stderr")" "Option -b needs an argument" || return 1
+  return 0
+}
+
 test_warns_when_the_identity_can_list_the_bucket () {
   AWS_LS_OK=1 backup -c STANDARD -e first
   assert_status "$?" 0 || return 1
@@ -758,6 +794,10 @@ run_test "a failing salt stops the backup"                         test_a_failin
 run_test "no arguments prints the usage"                           test_no_arguments_prints_usage
 run_test "an unknown subvolume is an error"                        test_unknown_subvolume_is_an_error
 run_test "a listable bucket raises a security warning"             test_warns_when_the_identity_can_list_the_bucket
+run_test "the upload is told how big a chunk is"                   test_the_upload_is_told_how_big_a_chunk_is
+run_test "nested subvolumes are reported"                          test_nested_subvolumes_are_reported
+run_test "an unknown option is reported with its name"             test_an_unknown_option_is_reported_with_its_name
+run_test "an option without its argument is reported"              test_an_option_without_its_argument_is_reported
 
 echo "Running the backup failure tests"
 run_test "a failing chunk upload fails the backup"                 test_failing_chunk_upload_fails_the_backup

--- a/tests/stubs/aws
+++ b/tests/stubs/aws
@@ -41,7 +41,7 @@ case ${service} in
           mkdir -p -- "${S3ROOT}/${bucket}/$(dirname -- "${key}")"
           cat >"${S3ROOT}/${bucket}/${key}"
           if [ "${FAIL_STAGE}" = aws ] && [ -n "${FAIL_CHUNK}" ] \
-             && [ "${key}" != "${key%${FAIL_CHUNK}}" ]; then
+             && [ "${key}" != "${key%"${FAIL_CHUNK}"}" ]; then
             rm -f -- "${S3ROOT}/${bucket}/${key}"
             echo "upload failed: An error occurred (AccessDenied)" >&2
             exit 1
@@ -102,7 +102,7 @@ case ${service} in
         exit 0
         ;;
       head-object)
-        if [ -n "${AWS_HEAD_ERROR}" ] && [ "${key}" != "${key%${AWS_HEAD_ERROR}}" ]; then
+        if [ -n "${AWS_HEAD_ERROR}" ] && [ "${key}" != "${key%"${AWS_HEAD_ERROR}"}" ]; then
           echo "An error occurred (503) when calling the HeadObject operation" >&2
           exit 254
         fi
@@ -110,7 +110,7 @@ case ${service} in
           echo "An error occurred (404) when calling the HeadObject operation: Not Found" >&2
           exit 254
         fi
-        if [ -n "${AWS_ARCHIVED}" ] && [ "${key}" != "${key%${AWS_ARCHIVED}}" ]; then
+        if [ -n "${AWS_ARCHIVED}" ] && [ "${key}" != "${key%"${AWS_ARCHIVED}"}" ]; then
           printf 'DEEP_ARCHIVE\tNone\n'
         else
           printf 'STANDARD\tNone\n'

--- a/tests/stubs/aws
+++ b/tests/stubs/aws
@@ -47,6 +47,11 @@ case ${service} in
             exit 1
           fi
           log "UPLOADED: ${bucket}/${key}"
+          prev=""
+          for arg in "$@"; do
+            [ "${prev}" = "--expected-size" ] && log "EXPECTED_SIZE: ${arg}"
+            prev=${arg}
+          done
           exit 0
         fi
         key=${src#s3://}

--- a/tests/stubs/btrfs
+++ b/tests/stubs/btrfs
@@ -25,8 +25,9 @@ fs_path () {
   # Filesystem-tree path of $1, the way 'btrfs subvolume show' prints it: the
   # path relative to the root of the filesystem, which for the top-level
   # subvolume (id 5) is reported as "/".
-  local prefix=${FS_PREFIX:-$(basename -- "${TEST_SUBV}")}
-  local rel=${1#"${TEST_SUBV}"}
+  local prefix rel
+  prefix=${FS_PREFIX:-$(basename -- "${TEST_SUBV}")}
+  rel=${1#"${TEST_SUBV}"}
   rel=${rel#/}
   if [ -z "${rel}" ]; then
     printf '%s\n' "${prefix}"
@@ -137,9 +138,11 @@ case "$1 $2" in
     printf '\tUUID:\t\t\t11111111-2222-3333-4444-555555555555\n'
     printf '\tCreation time:\t\t2026-01-01 00:00:00 +0000\n'
     printf '\tSnapshot(s):\n'
-    for d in "${TEST_SUBV}"/.stream_backup_*/*/; do
+    # Staged snapshots are listed too: btrfs knows nothing about which directory
+    # we keep a snapshot in, so nothing here may either.
+    for d in "${TEST_SUBV}"/.stream_backup_*/*/ "${TEST_SUBV}"/.stream_backup_*/.incomplete/*/; do
       [ -d "${d}" ] || continue
-      case ${d} in *"/.incomplete/"*) continue ;; esac
+      case ${d} in */.incomplete/) continue ;; esac
       printf '\t\t\t\t%s\n' "$(fs_path "${d%/}")"
     done
     exit 0


### PR DESCRIPTION
**Severity: medium and below.** The tail of the review, plus the lint gate that was held back so it would land on a tree that passes it.

**Nested subvolumes are silently left out.** Neither snapshots nor the stream descend into a subvolume nested inside the one being backed up: it arrives as an empty directory. Docker's btrfs driver, snapper and LXD all create them under paths people back up, the backup exits 0, the restore succeeds, and the data simply is not there. Nothing said so anywhere. It is now reported before the snapshot is taken.

**Chunks above about 78GiB could never upload.** Uploading from a stream, the AWS CLI cannot know how much is coming, so it uses 8MiB parts and gives up at the 10000 part limit. Nothing bounded `-S`, so a larger chunk size failed every upload — and, before this series, did so silently. It is now told the chunk size.

**`mbuffer` no longer grows with the chunk size.** It was given the chunk size, so `-S 5G` asked for five gigabytes of memory as well as five gigabyte objects — and a buffer that big is a good candidate for the OOM killer half way through a backup, which was one of the silent-truncation paths. It has its own `-m` option now, defaulting to what the default chunk size gave before, so nothing changes unless you had raised `-S`. Restore gets the same option.

**Option handling.** Without a leading colon in the option string, getopts printed its own message and left `OPTARG` unset, so the script's own message came out as `Invalid option: -.` after it, and a missing argument was not told apart from an unknown option. Both now name the option, on stderr. Anything left over on the command line is refused instead of quietly ignored.

**The README's security section overstated its own control.** It said there is no way to prevent an object being overwritten on S3. Versioning keeps the overwritten version, and Object Lock makes objects immutable outright. Salted names are still worth having, but the object name is visible in the process list while the upload runs, so they are defence in depth, not the control.

Plus the remaining unquoted expansions — these run as root and hand paths to `btrfs subvolume delete` — and a typo sweep across the docs, examples and runtime messages, including the warning printed during a restore.

Finally, CI gains a `shellcheck --severity=warning` job.

> One caveat worth stating plainly: shellcheck is not installed on the machine this was written on and I did not install one, so this job's first CI run is its first real execution. Everything is `bash -n` clean and the known warning-level patterns (SC2086, SC2155, SC2295) have been dealt with, but if it comes back red it will be a small follow-up.

**Verification:** four new tests covering the nested-subvolume warning, both option-error paths, and the chunk size being passed to the upload. Suite: 48 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)