### PR TITLE
Keep it small

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ These scripts rely on well known command line tools and the AWS CLI:
 * aws cli
 * mbuffer
 * lz4
-* split
-* sed
+* split, sed, numfmt (all in coreutils except sed)
 * age (or [rage](https://github.com/str4d/rage/) symlinked to `age` binary in PATH)
 * btrfs-tools
 * openssl

--- a/check_deps.sh
+++ b/check_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for cmd in age aws lz4 mbuffer split sed btrfs openssl flock; do
+for cmd in age aws lz4 mbuffer split sed btrfs openssl flock numfmt; do
   if ! command -v "${cmd}" &> /dev/null; then
     echo "command not found: ${cmd}" >&2
     exit 3

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -99,85 +99,38 @@ trap 'on_signal INT' INT
 trap 'on_signal TERM' TERM
 trap 'on_signal HUP' HUP
 
-# Whether a chunk can be read right now: present, missing, archived or error.
+# Writes the decrypted chunks of one sequence to stdout, in order, stopping at
+# the first name that does not exist: the chunk names are generated, not
+# listed. 0: the whole sequence, 1: something failed, 4: still in Glacier.
 # head-object answers 200 for an object that is in Glacier and has not been
-# restored to S3 Standard, so the storage class has to be looked at to tell
-# "not there" from "not there yet".
-function chunk_state () {
-  local key=$1
-  local out status class restore
-
-  out=$(aws s3api head-object --bucket "${BUCKET}" --key "${key}" \
-          --query '[StorageClass,Restore]' --output text 2>&1)
-  status=$?
-
-  if [ "${status}" -ne 0 ]; then
-    case ${out} in
-      *"(404)"*|*"Not Found"*)
-        printf 'missing\n'
-        ;;
-      *)
-        printf '%s\n' "${out}" >&2
-        printf 'error\n'
-        ;;
-    esac
-    return 0
-  fi
-
-  read -r class restore <<<"${out}"
-
-  case ${class} in
-    GLACIER|DEEP_ARCHIVE)
-      case ${restore} in
-        *'ongoing-request="false"'*) printf 'present\n' ;;
-        *)                           printf 'archived\n' ;;
-      esac
-      ;;
-    *)
-      printf 'present\n'
-      ;;
-  esac
-}
-
-# Writes the decrypted chunks of one sequence to stdout, in order.
-# 0: the whole sequence, 1: something failed, 4: still in Glacier.
+# restored to S3 Standard, so the storage class tells "not there" from "not
+# there yet".
 function fetch_chunks () {
-  local seq_prefix=$1
-  local key state
-  local -a status
+  local key head class restore
 
-  for key in "${seq_prefix}"x{a..z}{a..z}{a..z}{a..z}; do
-    state=$(chunk_state "${key}")
+  for key in "$1"x{a..z}{a..z}{a..z}{a..z}; do
+    if ! head=$(aws s3api head-object --bucket "${BUCKET}" --key "${key}" \
+                  --query '[StorageClass,Restore]' --output text 2>&1); then
+      case ${head} in
+        *"(404)"*|*"Not Found"*) return 0 ;;
+      esac
+      echo "ERROR: could not tell whether ${key} exists: ${head}" >&2
+      return 1
+    fi
 
-    case ${state} in
-      missing)
-        # The end of the sequence: the chunk names are generated, not listed.
-        return 0
-        ;;
-      archived)
-        echo "ERROR: ${key} is still in Glacier or Deep Archive." >&2
-        echo "       Restore the objects under ${seq_prefix} to S3 Standard" >&2
-        echo "       first (see examples/README.md), then run this again." >&2
-        return 4
-        ;;
-      error)
-        echo "ERROR: could not tell whether ${key} exists, stopping rather than" >&2
-        echo "       feeding btrfs receive a stream that stops halfway." >&2
-        return 1
-        ;;
-    esac
+    read -r class restore <<<"${head}"
+    if [[ "${class}" == @(GLACIER|DEEP_ARCHIVE) && "${restore}" != *'ongoing-request="false"'* ]]; then
+      echo "ERROR: ${key} is still in Glacier or Deep Archive; restore it to S3 Standard first (see examples/README.md)" >&2
+      return 4
+    fi
 
-    aws s3 cp "s3://${BUCKET}/${key}" - | age -d -i "${IDENTITY_FILE}"
-    status=("${PIPESTATUS[@]}")
-
-    if [ "${status[0]}" -ne 0 ] || [ "${status[1]}" -ne 0 ]; then
-      echo "ERROR: chunk ${key} could not be read" \
-           "(aws=${status[0]} age=${status[1]})" >&2
+    if ! aws s3 cp "s3://${BUCKET}/${key}" - | age -d -i "${IDENTITY_FILE}"; then
+      echo "ERROR: chunk ${key} could not be read (aws=${PIPESTATUS[0]} age=${PIPESTATUS[1]})" >&2
       return 1
     fi
   done
 
-  echo "ERROR: ${seq_prefix} holds more chunks than the naming scheme allows" >&2
+  echo "ERROR: $1 holds more chunks than the naming scheme allows" >&2
   return 1
 }
 
@@ -205,27 +158,16 @@ for SEQ_PREFIX in "${SEQ_PREFIXES[@]}"; do
   fi
 
   echo "Restoring ${SEQ_PREFIX}"
-  fetch_chunks "${SEQ_PREFIX}" | mbuffer -m 1G -q | lz4 -d | btrfs receive "${DEST}"
-  STATUS=("${PIPESTATUS[@]}")
-
-  if [ "${STATUS[0]}" -ne 0 ] || [ "${STATUS[1]}" -ne 0 ] \
-     || [ "${STATUS[2]}" -ne 0 ] || [ "${STATUS[3]}" -ne 0 ]; then
-    echo "ERROR: restoring ${SEQ_PREFIX} failed (chunks=${STATUS[0]}" \
-         "mbuffer=${STATUS[1]} lz4=${STATUS[2]} btrfs receive=${STATUS[3]})" >&2
-    echo "       You may have to delete a partly received ${DEST%/}/${SEQ_NAME}" >&2
-    echo "       before trying again." >&2
-    if [ "${STATUS[0]}" -eq 4 ]; then
-      EXIT_CODE=4
-    else
-      EXIT_CODE=2
-    fi
-    # Every later sequence is an increment on this one, so there is no point
-    # carrying on.
+  if ! fetch_chunks "${SEQ_PREFIX}" | mbuffer -m 1G -q | lz4 -d | btrfs receive "${DEST}"; then
+    STATUS=("${PIPESTATUS[@]}")
+    echo "ERROR: restoring ${SEQ_PREFIX} failed (chunks=${STATUS[0]} mbuffer=${STATUS[1]} lz4=${STATUS[2]} btrfs receive=${STATUS[3]})" >&2
+    echo "       You may have to delete a partly received ${DEST%/}/${SEQ_NAME} before trying again." >&2
+    [ "${STATUS[0]}" -eq 4 ] && EXIT_CODE=4 || EXIT_CODE=2
+    # Every later sequence is an increment on this one.
     break
   fi
 
-  # The next snapshot in the chain is on disk, so the one it was built from can
-  # go.
+  # The next link of the chain is on disk, so the one it was built from can go.
   if [ "${DELETE_PREVIOUS}" == true ] && [ -n "${RESTORED_SEQ}" ]; then
     echo "Deleting previous snapshot ${DEST%/}/${RESTORED_SEQ}"
     btrfs subvolume delete "${DEST%/}/${RESTORED_SEQ}" \

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -21,9 +21,8 @@ function die () {
 }
 
 DELETE_PREVIOUS=false
-MBUFFER_SIZE="1G"
 
-OPTSTRING=":b:p:e:i:s:m:d"
+OPTSTRING=":b:p:e:i:s:d"
 
 while getopts "${OPTSTRING}" opt; do
   case ${opt} in
@@ -46,10 +45,6 @@ while getopts "${OPTSTRING}" opt; do
     s)
       echo "Restore path: ${OPTARG}"
       DEST=${OPTARG}
-      ;;
-    m)
-      echo "Buffer size: ${OPTARG}"
-      MBUFFER_SIZE=${OPTARG}
       ;;
     d) 
       echo "Delete all restored snapshots but the last one"
@@ -76,9 +71,6 @@ Usage:
   -p prefix   : a prefix to use in that bucket
   -e epoch    : epoch of the backup we want to restore
   -s path     : BTRFS path were to restore the backup
-  [-m size]   : how much of the stream to hold in memory while
-                restoring. Default to 1G, K,M,G suffixes are
-                supported
   [-d]        : after restoring each incremental backup, delete
                 the one it's based on to save space, thus
                 keeping only the last version
@@ -213,7 +205,7 @@ for SEQ_PREFIX in "${SEQ_PREFIXES[@]}"; do
   fi
 
   echo "Restoring ${SEQ_PREFIX}"
-  fetch_chunks "${SEQ_PREFIX}" | mbuffer -m "${MBUFFER_SIZE}" -q | lz4 -d | btrfs receive "${DEST}"
+  fetch_chunks "${SEQ_PREFIX}" | mbuffer -m 1G -q | lz4 -d | btrfs receive "${DEST}"
   STATUS=("${PIPESTATUS[@]}")
 
   if [ "${STATUS[0]}" -ne 0 ] || [ "${STATUS[1]}" -ne 0 ] \

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 #
-# Before anything else: the shebang can be bypassed with "sh restore_backup.sh",
-# and everything below assumes bash, starting with $EUID.
-if [ -z "${BASH_VERSION}" ]; then
-  echo "Please run with bash" >&2
-  exit 3
-fi
+# The shebang can be bypassed with "sh restore_backup.sh", and everything below
+# assumes bash, starting with $EUID.
+[ -n "${BASH_VERSION}" ] || { echo "Please run with bash" >&2; exit 3; }
 
 set -o pipefail
 
@@ -15,6 +12,13 @@ if [ "$EUID" -ne 0 ]
 fi
 
 "$(dirname "$0")/check_deps.sh" || exit 3
+
+function die () {
+  local code=$1
+  shift
+  printf '%s\n' "$@" >&2
+  exit "${code}"
+}
 
 DELETE_PREVIOUS=false
 MBUFFER_SIZE="1G"
@@ -52,22 +56,16 @@ while getopts "${OPTSTRING}" opt; do
       DELETE_PREVIOUS=true
       ;;
     :)
-      echo "Option -${OPTARG} needs an argument." >&2
-      exit 1
+      die 1 "Option -${OPTARG} needs an argument."
       ;;
     ?)
-      echo "Invalid option: -${OPTARG}." >&2
-      exit 1
+      die 1 "Invalid option: -${OPTARG}."
       ;;
   esac
 done
 
 shift $((OPTIND - 1))
-
-if [ $# -ne 0 ]; then
-  echo "Unexpected argument: $1" >&2
-  exit 1
-fi
+[ $# -eq 0 ] || die 1 "Unexpected argument: $1"
 
 if [ "" == "$IDENTITY_FILE" ] || [ "" == "$BUCKET" ] || [ "" == "$PREFIX" ] || [ "" == "$EPOCH" ] || [ "" == "$DEST" ]; then
 cat << EOF
@@ -191,16 +189,11 @@ function fetch_chunks () {
   return 1
 }
 
-if ! SEQ_LIST=$(aws s3api list-objects-v2 --bucket "${BUCKET}" \
-      --prefix "${PREFIX}/${EPOCH}/" --delimiter '/' \
-      --query 'CommonPrefixes[].[Prefix]' --output text); then
-  echo "ERROR: could not list s3://${BUCKET}/${PREFIX}/${EPOCH}/" >&2
-  exit 1
-fi
-
+SEQ_LIST=$(aws s3api list-objects-v2 --bucket "${BUCKET}" --prefix "${PREFIX}/${EPOCH}/" \
+             --delimiter '/' --query 'CommonPrefixes[].[Prefix]' --output text) \
+  || die 1 "ERROR: could not list s3://${BUCKET}/${PREFIX}/${EPOCH}/"
 if [ -z "${SEQ_LIST}" ] || [ "${SEQ_LIST}" == "None" ]; then
-  echo "ERROR: no backup found in s3://${BUCKET}/${PREFIX}/${EPOCH}/" >&2
-  exit 1
+  die 1 "ERROR: no backup found in s3://${BUCKET}/${PREFIX}/${EPOCH}/"
 fi
 
 mapfile -t SEQ_PREFIXES < <(printf '%s\n' "${SEQ_LIST}" | LC_ALL=C sort)

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 #
-# Before anything else: the shebang can be bypassed with "sh stream_backup.sh",
-# and everything below assumes bash, starting with $EUID.
-if [ -z "${BASH_VERSION}" ]; then
-  echo "Please run with bash" >&2
-  exit 3
-fi
+# The shebang can be bypassed with "sh stream_backup.sh", and everything below
+# assumes bash, starting with $EUID.
+[ -n "${BASH_VERSION}" ] || { echo "Please run with bash" >&2; exit 3; }
 
 set -o pipefail
 
@@ -16,17 +13,18 @@ fi
 
 "$(dirname "$0")/check_deps.sh" || exit 3
 
+function die () {
+  local code=$1
+  shift
+  printf '%s\n' "$@" >&2
+  exit "${code}"
+}
+
 # GNU split runs its --filter through $SHELL, which is the login shell of
 # whoever started us and need not even be bash. Pin it to the interpreter
 # running this script so the filter's own error handling behaves predictably.
-SPLIT_SHELL=${BASH}
-if [ ! -x "${SPLIT_SHELL}" ]; then
-  SPLIT_SHELL=$(command -v bash)
-fi
-if [ ! -x "${SPLIT_SHELL}" ]; then
-  echo "command not found: bash (needed by 'split --filter')" >&2
-  exit 3
-fi
+SPLIT_SHELL=${BASH:-$(command -v bash)}
+[ -x "${SPLIT_SHELL}" ] || die 3 "command not found: bash (needed by 'split --filter')"
 
 SEND_LOG=""
 SNAPSHOT_STAGED=""
@@ -83,22 +81,16 @@ while getopts "${OPTSTRING}" opt; do
       DELETE_PREVIOUS=true
       ;;
     :)
-      echo "Option -${OPTARG} needs an argument." >&2
-      exit 1
+      die 1 "Option -${OPTARG} needs an argument."
       ;;
     ?)
-      echo "Invalid option: -${OPTARG}." >&2
-      exit 1
+      die 1 "Invalid option: -${OPTARG}."
       ;;
   esac
 done
 
 shift $((OPTIND - 1))
-
-if [ $# -ne 0 ]; then
-  echo "Unexpected argument: $1" >&2
-  exit 1
-fi
+[ $# -eq 0 ] || die 1 "Unexpected argument: $1"
 
 if [ "" == "$RECIPIENTS_FILE" ] || [ "" == "$BUCKET" ] || [ "" == "$PREFIX" ] || [ "" == "$EPOCH" ] || [ "" == "$SCLASS" ] || [ "" == "$SUBV" ]; then
 cat << EOF
@@ -213,20 +205,11 @@ function latest_snapshot () {
 # deletes one. The lock is held by the whole process tree, so a run whose upload
 # is stuck still counts as a run in progress.
 LOCK_DIR=/run/lock
-if [ ! -d "${LOCK_DIR}" ] || [ ! -w "${LOCK_DIR}" ]; then
-  LOCK_DIR=${TMPDIR:-/tmp}
-fi
-
+[ -w "${LOCK_DIR}" ] || LOCK_DIR=${TMPDIR:-/tmp}
 LOCK_NAME=${SUBV%/}
-LOCK_FILE=${LOCK_DIR}/stream_backup${LOCK_NAME//\//_}.lock
-
-exec 9>"${LOCK_FILE}" || exit 1
-
-if ! flock -n 9; then
-  echo "ERROR: another stream_backup.sh run is already working on ${SUBV}" >&2
-  echo "       (lock file ${LOCK_FILE}). Refusing to run two at once." >&2
-  exit 1
-fi
+exec 9>"${LOCK_DIR}/stream_backup${LOCK_NAME//\//_}.lock" || exit 1
+flock -n 9 \
+  || die 1 "ERROR: another stream_backup.sh run is already working on ${SUBV}. Refusing to run two at once."
 
 aws s3 ls "s3://${BUCKET}/${PREFIX}" >/dev/null 2>&1 \
   && echo "SECURITY WARNING: current AWS IAM entity is allowed to list bucket contents! This can allow an attacker using the same identity to overwrite files and ruin your backups!" >&2
@@ -234,32 +217,16 @@ aws s3 ls "s3://${BUCKET}/${PREFIX}" >/dev/null 2>&1 \
 SEQ=$(date +%s)
 
 # Salting the file names in S3 is important as to prevent malevolent overwriting
-SALT=$(openssl rand -hex 8)
+SEQ_SALTED=${SEQ}_$(openssl rand -hex 8)
+[ "${SEQ_SALTED}" != "${SEQ}_" ] || die 1 "ERROR: could not generate a random salt for the object names"
 
-if [ -z "${SALT}" ]; then
-  echo "ERROR: could not generate a random salt for the object names" >&2
-  exit 1
-fi
+btrfs subvolume show "${SUBV}" >/dev/null 2>&1 || die 1 "Subvolume not found"
 
-SEQ_SALTED=${SEQ}_${SALT}
-
-if ! btrfs subvolume show "${SUBV}" >/dev/null 2>&1; then
-  echo "Subvolume not found" >&2
-  exit 1
-fi
-
-# Snapshots are not recursive, and neither is the stream: a subvolume nested
-# inside this one arrives as an empty directory. Docker's btrfs driver, snapper
-# and LXD all create them under paths people back up.
-NESTED=$(btrfs subvolume list -o "${SUBV}" 2>/dev/null \
-           | grep -v '/\.stream_backup_' || true)
-
-if [ -n "${NESTED}" ]; then
-  echo "WARNING: ${SUBV} contains nested subvolumes. They will be backed up as" >&2
-  echo "         EMPTY directories, because snapshots do not descend into them." >&2
-  echo "         Back them up separately if you need their contents:" >&2
-  printf '%s\n' "${NESTED}" >&2
-fi
+# Snapshots are not recursive: a subvolume nested inside this one is backed up
+# as an empty directory.
+NESTED=$(btrfs subvolume list -o "${SUBV}" 2>/dev/null | grep -v '/\.stream_backup_' || true)
+[ -z "${NESTED}" ] \
+  || printf 'WARNING: nested subvolumes will be backed up as EMPTY directories:\n%s\n' "${NESTED}" >&2
 
 EPOCH_DIR=${SUBV%/}/.stream_backup_${EPOCH}
 # A snapshot is only moved out of here once its upload has completed, so
@@ -275,22 +242,14 @@ LAST_SNAPSHOT=$(latest_snapshot "${EPOCH_DIR}")
 if [ -z "${LAST_SNAPSHOT}" ] && [ -n "${SOURCE_EPOCH}" ]; then
   PARENT_DIR=${SUBV%/}/.stream_backup_${SOURCE_EPOCH}
   LAST_SNAPSHOT=$(latest_snapshot "${PARENT_DIR}")
-  if [ -z "${LAST_SNAPSHOT}" ]; then
-    echo "ERROR: Neither the current epoch nor the branch epoch has an existing snapshot" >&2
-    exit 1
-  fi
+  [ -n "${LAST_SNAPSHOT}" ] \
+    || die 1 "ERROR: Neither the current epoch nor the branch epoch has an existing snapshot"
   SNAPSHOT_FROM_OTHER_EPOCH=true
 fi
 
-# Restoring replays sequences in the order of these numbers, so a snapshot that
-# sorts before the one it was made from could never be restored.
+# Restoring replays sequences in the order of these numbers.
 if [ -n "${LAST_SNAPSHOT}" ] && [ "${SEQ}" -le "${LAST_SNAPSHOT}" ]; then
-  echo "ERROR: this run's sequence number (${SEQ}) is not newer than the last" >&2
-  echo "       snapshot's (${LAST_SNAPSHOT}). The clock has gone backwards, or" >&2
-  echo "       a backup has already been taken this second. Restoring replays" >&2
-  echo "       sequences in numerical order, so this backup could not be" >&2
-  echo "       restored after its own parent. Fix the clock and run again." >&2
-  exit 1
+  die 1 "ERROR: sequence ${SEQ} is not newer than the last snapshot (${LAST_SNAPSHOT}): a backup ran this second already, or the clock has gone backwards"
 fi
 
 SEND_ARGS=()
@@ -311,16 +270,13 @@ trap 'on_signal TERM' TERM
 trap 'on_signal HUP' HUP
 trap 'exit 1' ERR
 
-if [ -d "${STAGE_DIR}" ]; then
-  for ORPHAN in "${STAGE_DIR}"/*; do
-    [ -e "${ORPHAN}" ] || continue
-    echo "WARNING: ${ORPHAN} was left behind by an interrupted backup." >&2
-    echo "         Its sequence in S3 was never completed and cannot be restored," >&2
-    echo "         so it cannot be used as a parent. Deleting it." >&2
-    btrfs subvolume delete "${ORPHAN}" >&2 \
-      || echo "WARNING: could not delete ${ORPHAN}, remove it by hand" >&2
-  done
-fi
+# Whatever is left in staging was interrupted mid-upload: its sequence has no
+# completion marker, so nothing may ever chain from it.
+for ORPHAN in "${STAGE_DIR}"/*; do
+  [ -e "${ORPHAN}" ] || continue
+  echo "WARNING: deleting ${ORPHAN}, left behind by an interrupted backup" >&2
+  btrfs subvolume delete "${ORPHAN}" >&2 || echo "WARNING: could not delete ${ORPHAN}, remove it by hand" >&2
+done
 
 mkdir -p -- "${STAGE_DIR}"
 btrfs subvolume snapshot -r "${SUBV}" "${SNAPSHOT_STAGED}" || exit 1
@@ -358,19 +314,10 @@ SEND_LOG=""
 # We only write the subvolume information to S3 at the end, as a marker of completion of the backup
 # having the subvolume information might help debugging tricky situations.
 SNAPSHOT_INFO=$(btrfs subvolume show "${SNAPSHOT_STAGED}")
+[ -n "${SNAPSHOT_INFO}" ] || die 2 "ERROR: btrfs subvolume show ${SNAPSHOT_STAGED} returned nothing"
 
-if [ -z "${SNAPSHOT_INFO}" ]; then
-  echo "ERROR: btrfs subvolume show ${SNAPSHOT_STAGED} returned nothing" >&2
-  exit 2
-fi
-
-if ! printf '%s\n' "${SNAPSHOT_INFO}" \
-  | age -R "${RECIPIENTS_FILE}" \
-  | aws s3 cp - "${S3_SEQ_URL}/snapshot_info.dat"
-then
-  echo "ERROR: could not upload the completion marker for ${SEQ_SALTED}" >&2
-  exit 2
-fi
+printf '%s\n' "${SNAPSHOT_INFO}" | age -R "${RECIPIENTS_FILE}" | aws s3 cp - "${S3_SEQ_URL}/snapshot_info.dat" \
+  || die 2 "ERROR: could not upload the completion marker for ${SEQ_SALTED}"
 
 # The sequence is complete in S3, so this snapshot is now a valid parent for the
 # next run and can leave the staging directory.

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -28,8 +28,6 @@ SPLIT_SHELL=${BASH:-$(command -v bash)}
 
 SEND_LOG=""
 SNAPSHOT_STAGED=""
-BACKUP_OK=false
-HOUSEKEEPING_FAILED=false
 DELETE_PREVIOUS=false
 CHUNK_SIZE="512M"
 SOURCE_EPOCH=""
@@ -115,33 +113,20 @@ EOF
         exit 1
 fi
 
-# Runs however the script ends, including on a signal. A snapshot that is still
-# staged is one whose upload did not finish, and the next run must not be able
-# to chain from it, so it goes.
+# Runs however the script ends, including on a signal, until the snapshot is
+# promoted. A snapshot still staged is one whose upload did not finish, and the
+# next run must not be able to chain from it, so it goes.
 function on_exit () {
   local status=$?
-
   trap - EXIT ERR INT TERM HUP
-
-  if [ -n "${SEND_LOG}" ]; then
-    rm -f -- "${SEND_LOG}"
+  [ -n "${SEND_LOG}" ] && rm -f -- "${SEND_LOG}"
+  [ "${status}" -ne 0 ] || status=1
+  if [ -n "${SNAPSHOT_STAGED}" ] && [ -e "${SNAPSHOT_STAGED}" ]; then
+    echo "Something went wrong, deleting the snapshot this run created" >&2
+    btrfs subvolume delete "${SNAPSHOT_STAGED}" >&2 \
+      || echo "ERROR: could not delete ${SNAPSHOT_STAGED}, remove it by hand" >&2
+    status=2
   fi
-
-  if [ "${BACKUP_OK}" != true ]; then
-    if [ -n "${SNAPSHOT_STAGED}" ] && [ -e "${SNAPSHOT_STAGED}" ]; then
-      echo "Something went wrong, deleting the snapshot this run created" >&2
-      btrfs subvolume delete "${SNAPSHOT_STAGED}" >&2 \
-        || echo "ERROR: could not delete ${SNAPSHOT_STAGED}, remove it by hand" >&2
-      status=2
-    elif [ "${status}" -eq 0 ]; then
-      status=1
-    fi
-  elif [ "${HOUSEKEEPING_FAILED}" == true ]; then
-    status=4
-  else
-    status=0
-  fi
-
   exit "${status}"
 }
 
@@ -281,25 +266,22 @@ printf '%s\n' "${SNAPSHOT_INFO}" | age -R "${RECIPIENTS_FILE}" | aws s3 cp - "${
   || die 2 "ERROR: could not upload the completion marker for ${SEQ_SALTED}"
 
 # The sequence is complete in S3, so this snapshot is now a valid parent for the
-# next run and can leave the staging directory.
+# next run and can leave the staging directory. The backup is done: from here on
+# nothing may touch it, so the traps come off.
 mv -T -- "${SNAPSHOT_STAGED}" "${NEW_SNAPSHOT}"
-BACKUP_OK=true
-trap - ERR
+trap - EXIT ERR INT TERM HUP
 rmdir -- "${STAGE_DIR}" 2>/dev/null
 
 # We delete the snapshot from which we made an incremental backup:
 # * If the user asked for it
 # * If there is a previous snapshot in the first place
 # * If the snapshot is not from another epoch
-# The backup is already safe in S3 by now, so failing here is not fatal.
+# The backup is already safe in S3 by now, so failing here is not a failed
+# backup: exit code 4.
 if     [ "${DELETE_PREVIOUS}" == true ] \
     && [ -n "${LAST_SNAPSHOT}" ] \
     && [ "${SNAPSHOT_FROM_OTHER_EPOCH}" == false ]; then
-  if ! btrfs subvolume delete "${PARENT_PATH}"; then
-    echo "WARNING: the backup completed, but the snapshot it was made from" >&2
-    echo "         (${PARENT_PATH}) could not be deleted. Snapshots will pile" >&2
-    echo "         up until this is dealt with." >&2
-    HOUSEKEEPING_FAILED=true
-  fi
+  btrfs subvolume delete "${PARENT_PATH}" \
+    || die 4 "WARNING: the backup completed and is safe, but ${PARENT_PATH} could not be deleted; snapshots will pile up until this is dealt with"
 fi
 

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -158,25 +158,6 @@ function on_signal () {
   exit 2
 }
 
-# A size in split's notation as a plain number of bytes, or nothing if it is
-# written in a way we do not recognise.
-function size_to_bytes () {
-  local size=$1
-  local number=${size%[KkMmGgTt]}
-
-  case ${number} in
-    ''|*[!0-9]*) return 0 ;;
-  esac
-
-  case ${size} in
-    *[0-9]) printf '%s\n' "${number}" ;;
-    *[Kk])  printf '%s\n' "$(( number * 1024 ))" ;;
-    *[Mm])  printf '%s\n' "$(( number * 1024 ** 2 ))" ;;
-    *[Gg])  printf '%s\n' "$(( number * 1024 ** 3 ))" ;;
-    *[Tt])  printf '%s\n' "$(( number * 1024 ** 4 ))" ;;
-  esac
-}
-
 # Name of the newest snapshot in a snapshot directory, or nothing if it holds
 # none. Our snapshots are named after the second they were taken in, so anything
 # that is not a plain number was not put there by this script.
@@ -284,10 +265,10 @@ btrfs subvolume snapshot -r "${SUBV}" "${SNAPSHOT_STAGED}" || exit 1
 SEND_LOG=$(mktemp) || exit 2
 
 S3_SEQ_URL="s3://${BUCKET}/${PREFIX}/${EPOCH}/${SEQ_SALTED}"
-# Uploading from a stream, the AWS CLI has no idea how much is coming, so it
-# uses 8MiB parts and runs into the 10000 part limit a little under 78GiB.
-# Telling it how big a chunk is lets it size the parts accordingly.
-EXPECTED_SIZE=$(size_to_bytes "${CHUNK_SIZE}")
+# Without a size the AWS CLI streams 8MiB parts and hits the 10000 part limit
+# just under 78GiB. split accepts suffixes numfmt does not, so a size that will
+# not parse just leaves the hint unset.
+EXPECTED_SIZE=$(numfmt --from=iec "${CHUNK_SIZE^^}" 2>/dev/null) || EXPECTED_SIZE=""
 export RECIPIENTS_FILE S3_SEQ_URL SCLASS EXPECTED_SIZE
 
 # stdout is the backup itself, and btrfs send writes progress as well as errors

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -150,27 +150,15 @@ function on_signal () {
   exit 2
 }
 
-# Name of the newest snapshot in a snapshot directory, or nothing if it holds
-# none. Our snapshots are named after the second they were taken in, so anything
-# that is not a plain number was not put there by this script.
+# Name of the newest snapshot in a snapshot directory, or nothing. Our
+# snapshots are named after the second they were taken in, so anything that is
+# not a plain number was not put there by this script.
 function latest_snapshot () {
-  local dir=$1
-  local path name newest=""
-
-  [ -d "${dir}" ] || return 0
-
-  for path in "${dir}"/*; do
-    name=${path##*/}
-    case ${name} in
-      ''|*[!0-9]*) continue ;;
-    esac
-    btrfs subvolume show "${path}" >/dev/null 2>&1 || continue
-    if [ -z "${newest}" ] || [ "${name}" -gt "${newest}" ]; then
-      newest=${name}
-    fi
-  done
-
-  printf '%s\n' "${newest}"
+  local path
+  for path in "$1"/*; do
+    path=${path##*/}
+    [[ "${path}" == +([0-9]) ]] && printf '%s\n' "${path}"
+  done | sort -n | tail -n 1
 }
 
 # One run at a time per subvolume, and per subvolume rather than per epoch: with

--- a/stream_backup.sh
+++ b/stream_backup.sh
@@ -32,11 +32,10 @@ BACKUP_OK=false
 HOUSEKEEPING_FAILED=false
 DELETE_PREVIOUS=false
 CHUNK_SIZE="512M"
-MBUFFER_SIZE="512M"
 SOURCE_EPOCH=""
 SNAPSHOT_FROM_OTHER_EPOCH=false
 
-OPTSTRING=":r:b:p:e:c:s:B:S:m:d"
+OPTSTRING=":r:b:p:e:c:s:B:S:d"
 
 while getopts "${OPTSTRING}" opt; do
   case ${opt} in
@@ -71,10 +70,6 @@ while getopts "${OPTSTRING}" opt; do
     S)
       echo "Chunks size: ${OPTARG}"
       CHUNK_SIZE=${OPTARG}
-      ;;
-    m)
-      echo "Buffer size: ${OPTARG}"
-      MBUFFER_SIZE=${OPTARG}
       ;;
     d) 
       echo "Will delete previous snapshot in the same epoch"
@@ -113,9 +108,6 @@ Usage:
                 backups into epochs of different periodicity
   [-S size]   : size of chunks to send to S3. Default to 512M
                 K,M,G suffixes are supported
-  [-m size]   : how much of the stream to hold in memory while
-                uploading. Default to 512M, K,M,G suffixes are
-                supported
   [-d]        : when the upload succeeds, delete the older snapshot
                 defaults to keep the old snapshot. Does not delete
                 the previous snapshot if it is in a different epoch
@@ -275,7 +267,7 @@ export RECIPIENTS_FILE S3_SEQ_URL SCLASS EXPECTED_SIZE
 # to stderr, so its stderr goes to a file and is shown only on failure.
 if ! btrfs send "${SEND_ARGS[@]}" 2>"${SEND_LOG}" \
 	| lz4 \
-	| mbuffer -m "${MBUFFER_SIZE}" -q \
+	| mbuffer -m 512M -q \
 	| SHELL="${SPLIT_SHELL}" split -b "${CHUNK_SIZE}" --suffix-length 4 --filter \
 	'set -o pipefail
 	 age -R "${RECIPIENTS_FILE}" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -376,6 +376,16 @@ test_the_upload_is_told_how_big_a_chunk_is () {
   return 0
 }
 
+# split accepts lowercase suffixes, so the size hint has to cope with them, and
+# a size the parser cannot read must not fail the backup: it just goes unhinted.
+test_a_lowercase_chunk_size_still_works () {
+  backup -c STANDARD -e first -S 512m
+  local status=$?
+  assert_status "${status}" 0 || return 1
+  assert_contains "$(actions)" "EXPECTED_SIZE: 536870912" || return 1
+  return 0
+}
+
 test_nested_subvolumes_are_reported () {
   NESTED_SUBVOLS="ID 256 gen 9 top level 5 path subv/var/lib/docker
 " backup -c STANDARD -e first
@@ -795,6 +805,7 @@ run_test "no arguments prints the usage"                           test_no_argum
 run_test "an unknown subvolume is an error"                        test_unknown_subvolume_is_an_error
 run_test "a listable bucket raises a security warning"             test_warns_when_the_identity_can_list_the_bucket
 run_test "the upload is told how big a chunk is"                   test_the_upload_is_told_how_big_a_chunk_is
+run_test "a lowercase chunk size still works"                      test_a_lowercase_chunk_size_still_works
 run_test "nested subvolumes are reported"                          test_nested_subvolumes_are_reported
 run_test "an unknown option is reported with its name"             test_an_unknown_option_is_reported_with_its_name
 run_test "an option without its argument is reported"              test_an_option_without_its_argument_is_reported

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -748,6 +748,17 @@ test_an_archived_chunk_is_reported_as_such () {
   return 0
 }
 
+# A transient head-object failure must not be read as "end of the sequence":
+# that would feed a silently truncated stream to btrfs receive.
+test_a_failed_chunk_check_stops_the_restore () {
+  backup -c STANDARD -e first || { fail "the first backup failed"; return 1; }
+  mkdir -p "${WORK}/dest"
+
+  AWS_HEAD_ERROR=xaaaa restore -e first -s "${WORK}/dest"
+  assert_status "$?" 2 || return 1
+  return 0
+}
+
 test_a_failed_listing_is_an_error () {
   mkdir -p "${WORK}/dest"
   AWS_LIST_FAIL=1 restore -e first -s "${WORK}/dest"
@@ -842,6 +853,7 @@ echo "Running the restore failure tests"
 run_test "a failed receive stops the restore"                      test_a_failed_receive_stops_the_restore
 run_test "a chunk that will not decrypt stops the restore"         test_a_chunk_that_will_not_decrypt_stops_the_restore
 run_test "an archived chunk is reported as such"                   test_an_archived_chunk_is_reported_as_such
+run_test "a failed chunk check stops the restore"                  test_a_failed_chunk_check_stops_the_restore
 run_test "a failed listing is an error"                            test_a_failed_listing_is_an_error
 run_test "an empty epoch is an error"                              test_an_empty_epoch_is_an_error
 run_test "restoring nothing at all is an error"                    test_restoring_nothing_at_all_is_an_error


### PR DESCRIPTION
The fix series more than doubled the two scripts: 168 → 397 lines for the backup, 103 → 257 for the restore. Correctness earned some of that, but not all of it — a lot was me writing error handling long-hand. This walks it back to **283 and 184 (467 total, −29%)** without giving back any of the guarantees:

- **A `die` helper.** Every error was a four-line `if/echo/echo/exit` block, and several messages had grown into paragraphs. One helper, one loud line each. This is most of the diff.
- **`numfmt` instead of my `size_to_bytes`.** coreutils already ships a size parser; seventeen lines of mine were not more auditable than one line of it. (The first cut of this had a real bug — `numfmt` rejects `512m`, which `split` accepts, and the failing substitution would have tripped the ERR trap and killed the backup with no diagnostic. Caught by adversarial review before pushing; suffixes are uppercased and the status explicitly swallowed, with a test pinning `-S 512m`.)
- **No `-m` option.** Nobody asked for a buffer knob — what mattered was only that the buffer stopped growing with `-S`. Pinned at 512M/1G, which is exactly what the defaults always gave.
- **`latest_snapshot` is one pipeline** (`ls | grep -Ex '[0-9]+' | sort -n | tail -1`). The old loop also verified each candidate with `btrfs subvolume show` and silently skipped failures; now a numbered non-subvolume in our own state directory makes `btrfs send` refuse the parent loudly instead of being quietly worked around. I think that's more honest, but it is a deliberate behaviour change — say so if you disagree.
- **Traps come off at promotion.** The exit handler juggled two flags (`BACKUP_OK`, `HOUSEKEEPING_FAILED`) to reconstruct, after the fact, whether the run had succeeded. Promotion *is* the success moment, so the traps come off there, the handler only ever sees failed runs, and both flags disappear. Consequence: a signal *after* promotion now kills the script with the default disposition instead of exiting 0 — the backup is safe either way, and dying honestly seems better than reporting success for interrupted housekeeping.
- **The restore's `chunk_state`/`fetch_chunks` pair is one function.** `chunk_state` produced a word that its only caller immediately turned back into actions. With `pipefail` carrying the verdict, the four-way `PIPESTATUS` test also collapses to a plain `if !`.

Verified by the 50-test suite (two tests added: lowercase chunk size, and the previously-untested transient head-object failure) plus three independent adversarial reviewers tracing every exit path on both branches — their only confirmed finding was the `numfmt` bug above, fixed before this was pushed.

What I did **not** cut: the staging directory, the lock, the per-stage pipeline checks, the Glacier discrimination and the marker-last protocol. Each remaining block maps to a verified way this tool used to lose data; the residual growth over the original 271 lines is, as far as I can tell, the actual price of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)